### PR TITLE
[46] Residents can locate problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'faker' # Use in all environments until we have a real API
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'haml-rails'
+gem 'jquery-rails'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.3'

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
   gem 'capybara'
   gem 'climate_control'
   gem 'launchy'
+  gem 'poltergeist'
   gem 'simplecov', require: false
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,10 @@ GEM
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
     i18n (0.8.6)
+    jquery-rails (4.3.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -266,6 +270,7 @@ DEPENDENCIES
   govuk_elements_rails
   govuk_frontend_toolkit
   haml-rails
+  jquery-rails
   launchy
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     climate_control (0.2.0)
+    cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -122,6 +123,10 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
+    poltergeist (1.16.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -264,6 +269,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
+  poltergeist
   pry-rails
   puma (~> 3.7)
   rails (~> 5.1.3)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,5 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require rails-ujs
+//= require jquery
+//= require jquery_ujs
 //= require_tree .

--- a/app/assets/javascripts/form.js
+++ b/app/assets/javascripts/form.js
@@ -1,0 +1,19 @@
+$(document).ready(function() {
+  $('body').addClass('js-enabled');
+
+  // Loop over each form on the page
+  $('form').each(function() {
+
+    // If the form contains radio buttons, hide the submit button
+    if ($(this).find('input[type=radio]').length > 0) {
+      $(this).find('input[type=button]').hide();
+      $(this).find('input[type=submit]').hide();
+    }
+
+    // Clicking on any radio button will show the submit button
+    if ($(this).find('input[type=radio]').click(function() {
+      $(this).closest('form').find('input[type=button]').show();
+      $(this).closest('form').find('input[type=submit]').show();
+    }));
+  });
+});

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -1,11 +1,15 @@
 class AddressSearchesController < ApplicationController
   def show
+    @address_search = AddressSearch.new
+  end
+
+  def update
     @address_search = AddressSearch.new(address_search_params[:address_search])
 
-    first_visit = address_search_params.empty?
-    @show_results = !first_visit && @address_search.valid?
-
-    return unless @show_results
+    unless @address_search.valid?
+      render :show
+      return
+    end
 
     address_finder = AddressFinder.new(HackneyApi.new)
     @address_search_results = address_finder.find(@address_search)

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -1,8 +1,19 @@
 class AddressSearchesController < ApplicationController
   def show
-    @address_search = AddressSearch.new
-    @address = Address.new
+    @address_search = AddressSearch.new(address_search_params[:address_search])
+
+    @first_visit = address_search_params.empty?
+    return if @first_visit
+
     address_finder = AddressFinder.new(HackneyApi.new)
     @address_search_results = address_finder.find(@address_search)
+
+    @address = Address.new
+  end
+
+  private
+
+  def address_search_params
+    params.permit(address_search: [:postcode])
   end
 end

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -2,5 +2,6 @@ class AddressSearchesController < ApplicationController
   def show
     @address_search = AddressSearch.new
     @address = Address.new
+    @address_search_results = AddressFinder.new.find(@address_search)
   end
 end

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -1,13 +1,13 @@
 class AddressSearchesController < ApplicationController
-  def show
+  def new
     @address_search = AddressSearch.new
   end
 
-  def update
+  def create
     @address_search = AddressSearch.new(address_search_params[:address_search])
 
     unless @address_search.valid?
-      render :show
+      render :new
       return
     end
 

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -2,6 +2,7 @@ class AddressSearchesController < ApplicationController
   def show
     @address_search = AddressSearch.new
     @address = Address.new
-    @address_search_results = AddressFinder.new.find(@address_search)
+    address_finder = AddressFinder.new(HackneyApi.new)
+    @address_search_results = address_finder.find(@address_search)
   end
 end

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -1,0 +1,6 @@
+class AddressSearchesController < ApplicationController
+  def show
+    @address_search = AddressSearch.new
+    @address = Address.new
+  end
+end

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -2,8 +2,10 @@ class AddressSearchesController < ApplicationController
   def show
     @address_search = AddressSearch.new(address_search_params[:address_search])
 
-    @first_visit = address_search_params.empty?
-    return if @first_visit
+    first_visit = address_search_params.empty?
+    @show_results = !first_visit && @address_search.valid?
+
+    return unless @show_results
 
     address_finder = AddressFinder.new(HackneyApi.new)
     @address_search_results = address_finder.find(@address_search)

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,0 +1,5 @@
+class AddressesController < ApplicationController
+  def update
+    redirect_to new_appointment_path
+  end
+end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,8 +1,8 @@
 class AddressesController < ApplicationController
-  def update
+  def create
     if property_reference.empty?
-      return redirect_back(
-        fallback_location: address_search_path,
+      return redirect_to(
+        new_address_search_path,
         alert: 'Please choose your address to continue'
       )
     end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,13 +1,16 @@
 class AddressesController < ApplicationController
   def update
-    selected_answers_store = SelectedAnswerStore.new(session)
-
-    property_reference = update_params[:property_reference]
+    if property_reference.empty?
+      return redirect_back(
+        fallback_location: address_search_path,
+        alert: 'Please choose your address to continue'
+      )
+    end
 
     api = HackneyApi.new
     address = api.get_property(property_reference: property_reference)
 
-    selected_answers_store.store_selected_answers('address', address)
+    SelectedAnswerStore.new(session).store_selected_answers('address', address)
 
     redirect_to new_appointment_path
   end
@@ -16,5 +19,9 @@ class AddressesController < ApplicationController
 
   def update_params
     params.require(:address).permit(:property_reference)
+  end
+
+  def property_reference
+    update_params[:property_reference]
   end
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,5 +1,20 @@
 class AddressesController < ApplicationController
   def update
+    selected_answers_store = SelectedAnswerStore.new(session)
+
+    property_reference = update_params[:property_reference]
+
+    api = HackneyApi.new
+    address = api.get_property(property_reference: property_reference)
+
+    selected_answers_store.store_selected_answers('address', address)
+
     redirect_to new_appointment_path
+  end
+
+  private
+
+  def update_params
+    params.require(:address).permit(:property_reference)
   end
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -3,7 +3,7 @@ class AddressesController < ApplicationController
     if property_reference.blank?
       return redirect_to(
         new_address_search_path,
-        alert: 'Please choose your address to continue'
+        alert: t('addresses.errors.blank')
       )
     end
 

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,6 +1,6 @@
 class AddressesController < ApplicationController
   def create
-    if property_reference.empty?
+    if property_reference.blank?
       return redirect_to(
         new_address_search_path,
         alert: 'Please choose your address to continue'

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,5 +1,6 @@
 class AppointmentsController < ApplicationController
   def new
-    # NO OP
+    selected_answer_store = SelectedAnswerStore.new(session)
+    @selected_answers = selected_answer_store.selected_answers['address']
   end
 end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,0 +1,5 @@
+class AppointmentsController < ApplicationController
+  def new
+    # NO OP
+  end
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,5 @@
 class Address
   include ActiveModel::Model
 
-  attr_accessor :address
+  attr_accessor :property_reference, :short_address
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,5 @@
+class Address
+  include ActiveModel::Model
+
+  attr_accessor :address
+end

--- a/app/models/address_search.rb
+++ b/app/models/address_search.rb
@@ -3,7 +3,10 @@ class AddressSearch
 
   attr_accessor :postcode
 
+  validates :postcode, presence: true, postcode: { allow_blank: true }
+
   def data
     { postcode: postcode }
   end
 end
+

--- a/app/models/address_search.rb
+++ b/app/models/address_search.rb
@@ -12,7 +12,7 @@ class AddressSearch
   private
 
   def normalised_postcode
-    postcode.strip.gsub(/\s+/, ' ').upcase
+    postcode.strip.gsub(/\s+/, '').insert(-4, ' ').upcase
   end
 end
 

--- a/app/models/address_search.rb
+++ b/app/models/address_search.rb
@@ -6,7 +6,13 @@ class AddressSearch
   validates :postcode, presence: true, postcode: { allow_blank: true }
 
   def data
-    { postcode: postcode }
+    { postcode: normalised_postcode }
+  end
+
+  private
+
+  def normalised_postcode
+    postcode.strip.gsub(/\s+/, ' ').upcase
   end
 end
 

--- a/app/models/address_search.rb
+++ b/app/models/address_search.rb
@@ -2,4 +2,8 @@ class AddressSearch
   include ActiveModel::Model
 
   attr_accessor :postcode
+
+  def data
+    { postcode: postcode }
+  end
 end

--- a/app/models/address_search.rb
+++ b/app/models/address_search.rb
@@ -1,0 +1,5 @@
+class AddressSearch
+  include ActiveModel::Model
+
+  attr_accessor :postcode
+end

--- a/app/models/selected_answer_store.rb
+++ b/app/models/selected_answer_store.rb
@@ -1,0 +1,13 @@
+class SelectedAnswerStore
+  def initialize(session)
+    @session = session
+  end
+
+  def store_selected_answers(key, value)
+    selected_answers[key] = value
+  end
+
+  def selected_answers
+    @session[:selected_answers] ||= {}
+  end
+end

--- a/app/queries/address_finder.rb
+++ b/app/queries/address_finder.rb
@@ -1,9 +1,17 @@
 class AddressFinder
-  def find(_form)
-    [
-      Result.new('P01234', 'Flat 1, 8 Hoxton Square, N1 6NU'),
-    ]
+  def initialize(api)
+    @api = api
   end
 
-  Result = Struct.new(:property_reference, :short_address)
+  def find(form)
+    properties = @api.list_properties(form.data[:postcode])
+    properties.map do |property|
+      Property.new(
+        property['property_reference'],
+        property['short_address']
+      )
+    end
+  end
+
+  Property = Struct.new(:property_reference, :short_address)
 end

--- a/app/queries/address_finder.rb
+++ b/app/queries/address_finder.rb
@@ -4,7 +4,7 @@ class AddressFinder
   end
 
   def find(form)
-    properties = @api.list_properties(form.data[:postcode])
+    properties = @api.list_properties(postcode: form.data[:postcode])
     properties.map do |property|
       Property.new(
         property['property_reference'],

--- a/app/queries/address_finder.rb
+++ b/app/queries/address_finder.rb
@@ -1,0 +1,5 @@
+class AddressFinder
+  def find(_form)
+    [['P01234', 'Flat 1, 8 Hoxton Square, N1 6NU']]
+  end
+end

--- a/app/queries/address_finder.rb
+++ b/app/queries/address_finder.rb
@@ -1,5 +1,9 @@
 class AddressFinder
   def find(_form)
-    [['P01234', 'Flat 1, 8 Hoxton Square, N1 6NU']]
+    [
+      Result.new('P01234', 'Flat 1, 8 Hoxton Square, N1 6NU'),
+    ]
   end
+
+  Result = Struct.new(:property_reference, :short_address)
 end

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -6,4 +6,8 @@ class HackneyApi
   def list_properties(postcode:)
     @json_api.get('properties?postcode=' + postcode)
   end
+
+  def get_property(property_reference:)
+    @json_api.get('properties/' + property_reference)
+  end
 end

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -1,0 +1,2 @@
+class HackneyApi
+end

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -1,2 +1,9 @@
 class HackneyApi
+  def initialize(json_api = JsonApi.new)
+    @json_api = json_api
+  end
+
+  def list_properties(postcode:)
+    @json_api.get('properties?postcode=' + postcode)
+  end
 end

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -1,10 +1,35 @@
 class JsonApi
-  def get(_path)
+  def get(path)
+    case path
+    when /^properties\?postcode=/
+      fake_property_search_results
+    when %r{^properties\/}
+      fake_property
+    else
+      {}
+    end
+  end
+
+  private
+
+  def fake_property_search_results
     [
+      {
+        'property_reference' => 'abc123',
+        'short_address' => '220 Aardvark Road, A1 1AA',
+      },
       {
         'property_reference' => 'zxc987',
         'short_address' => '221B Aardvark Road, A1 1AA',
       },
     ]
+  end
+
+  def fake_property
+    {
+      'property_reference' => 'zxc987',
+      'short_address' => '221B Aardvark Road, A1 1AA',
+      'uprn' => '123456789',
+    }
   end
 end

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -1,0 +1,10 @@
+class JsonApi
+  def get(_path)
+    [
+      {
+        'property_reference' => 'zxc987',
+        'short_address' => '221B Aardvark Road, A1 1AA',
+      },
+    ]
+  end
+end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,0 +1,15 @@
+class PostcodeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if valid_postcode?(value)
+    message = (options[:message] || "doesn't seem to be valid")
+    record.errors[attribute] << message
+  end
+
+  private
+
+  def valid_postcode?(postcode)
+    # Adapted from https://gist.github.com/mudge/163332
+    # rubocop:disable LineLength
+    postcode =~ /^\s*((GIR\s*0AA)|((([A-PR-UWYZ][0-9]{1,2})|(([A-PR-UWYZ][A-HK-Y][0-9]{1,2})|(([A-PR-UWYZ][0-9][A-HJKSTUW])|([A-PR-UWYZ][A-HK-Y][0-9][ABEHMNPRVWXY]))))\s*[0-9][ABD-HJLNP-UW-Z]{2}))\s*$/i
+  end
+end

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -1,14 +1,14 @@
 - if @address_search.errors
   = @address_search.errors.full_messages.join(', ')
 
-= simple_form_for @address_search, url: address_search_path, method: :get do |f|
+%p
   = @address_search.postcode
-  = f.button :submit, t('address_search.change')
+  = link_to t('address_search.change'), new_address_search_path
 
 - if @address_search_results
   #address-search-results
     - if @address_search_results.any?
-      = simple_form_for @address, method: :put do |f|
+      = simple_form_for @address, url: address_path do |f|
         = f.collection_radio_buttons :property_reference, @address_search_results, :property_reference, :short_address
         = f.button :submit
     - else

--- a/app/views/address_searches/new.html.haml
+++ b/app/views/address_searches/new.html.haml
@@ -1,7 +1,7 @@
 - if @address_search.errors
   = @address_search.errors.full_messages.join(', ')
 
-= simple_form_for @address_search, url: address_search_path, method: :put do |f|
+= simple_form_for @address_search, url: address_search_path do |f|
   = f.input :postcode
   = f.button :submit
 

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -5,5 +5,5 @@
 - unless @first_visit
   = simple_form_for @address, method: :put do |f|
     #address-search-results
-      = f.collection_radio_buttons :address, @address_search_results, :property_reference, :short_address
+      = f.collection_radio_buttons :property_reference, @address_search_results, :property_reference, :short_address
       = f.button :submit

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -2,7 +2,8 @@
   = f.input :postcode
   = f.button :submit
 
-= simple_form_for @address, method: :put do |f|
-  #address-search-results
-    = f.collection_radio_buttons :address, @address_search_results, :property_reference, :short_address
-    = f.button :submit
+- unless @first_visit
+  = simple_form_for @address, method: :put do |f|
+    #address-search-results
+      = f.collection_radio_buttons :address, @address_search_results, :property_reference, :short_address
+      = f.button :submit

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -1,0 +1,8 @@
+= simple_form_for @address_search, url: address_search_path, method: :get do |f|
+  = f.input :postcode
+  = f.button :submit
+
+= simple_form_for @address, method: :put do |f|
+  #address-search-results
+    = f.collection_radio_buttons :address, [['P01234', 'Flat 1, 8 Hoxton Square, N1 6NU']], :first, :last
+    = f.button :submit

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -3,7 +3,10 @@
   = f.button :submit
 
 - unless @first_visit
-  = simple_form_for @address, method: :put do |f|
-    #address-search-results
-      = f.collection_radio_buttons :property_reference, @address_search_results, :property_reference, :short_address
-      = f.button :submit
+  #address-search-results
+    - if @address_search_results.any?
+      = simple_form_for @address, method: :put do |f|
+        = f.collection_radio_buttons :property_reference, @address_search_results, :property_reference, :short_address
+        = f.button :submit
+    - else
+      = t('address_search.not_found')

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -1,8 +1,11 @@
+- if @address_search.errors
+  = @address_search.errors.full_messages.join(', ')
+
 = simple_form_for @address_search, url: address_search_path, method: :get do |f|
   = f.input :postcode
   = f.button :submit
 
-- unless @first_visit
+- if @show_results
   #address-search-results
     - if @address_search_results.any?
       = simple_form_for @address, method: :put do |f|

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -4,5 +4,5 @@
 
 = simple_form_for @address, method: :put do |f|
   #address-search-results
-    = f.collection_radio_buttons :address, @address_search_results, :first, :last
+    = f.collection_radio_buttons :address, @address_search_results, :property_reference, :short_address
     = f.button :submit

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -4,5 +4,5 @@
 
 = simple_form_for @address, method: :put do |f|
   #address-search-results
-    = f.collection_radio_buttons :address, [['P01234', 'Flat 1, 8 Hoxton Square, N1 6NU']], :first, :last
+    = f.collection_radio_buttons :address, @address_search_results, :first, :last
     = f.button :submit

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -1,11 +1,11 @@
 - if @address_search.errors
   = @address_search.errors.full_messages.join(', ')
 
-= simple_form_for @address_search, url: address_search_path, method: :get do |f|
-  = f.input :postcode
-  = f.button :submit
-
 - if @show_results
+  = simple_form_for @address_search, url: address_search_path, method: :get do |f|
+    = @address_search.postcode
+    = f.button :submit, 'Change'
+
   #address-search-results
     - if @address_search_results.any?
       = simple_form_for @address, method: :put do |f|
@@ -13,3 +13,8 @@
         = f.button :submit
     - else
       = t('address_search.not_found')
+- else
+  = simple_form_for @address_search, url: address_search_path, method: :get do |f|
+    = f.input :postcode
+    = f.button :submit
+

--- a/app/views/address_searches/show.html.haml
+++ b/app/views/address_searches/show.html.haml
@@ -1,20 +1,7 @@
 - if @address_search.errors
   = @address_search.errors.full_messages.join(', ')
 
-- if @show_results
-  = simple_form_for @address_search, url: address_search_path, method: :get do |f|
-    = @address_search.postcode
-    = f.button :submit, 'Change'
-
-  #address-search-results
-    - if @address_search_results.any?
-      = simple_form_for @address, method: :put do |f|
-        = f.collection_radio_buttons :property_reference, @address_search_results, :property_reference, :short_address
-        = f.button :submit
-    - else
-      = t('address_search.not_found')
-- else
-  = simple_form_for @address_search, url: address_search_path, method: :get do |f|
-    = f.input :postcode
-    = f.button :submit
+= simple_form_for @address_search, url: address_search_path, method: :put do |f|
+  = f.input :postcode
+  = f.button :submit
 

--- a/app/views/address_searches/update.html.haml
+++ b/app/views/address_searches/update.html.haml
@@ -1,0 +1,16 @@
+- if @address_search.errors
+  = @address_search.errors.full_messages.join(', ')
+
+= simple_form_for @address_search, url: address_search_path, method: :get do |f|
+  = @address_search.postcode
+  = f.button :submit, 'Change'
+
+- if @address_search_results
+  #address-search-results
+    - if @address_search_results.any?
+      = simple_form_for @address, method: :put do |f|
+        = f.collection_radio_buttons :property_reference, @address_search_results, :property_reference, :short_address
+        = f.button :submit
+    - else
+      = t('address_search.not_found')
+

--- a/app/views/address_searches/update.html.haml
+++ b/app/views/address_searches/update.html.haml
@@ -3,7 +3,7 @@
 
 = simple_form_for @address_search, url: address_search_path, method: :get do |f|
   = @address_search.postcode
-  = f.button :submit, 'Change'
+  = f.button :submit, t('address_search.change')
 
 - if @address_search_results
   #address-search-results

--- a/app/views/appointments/new.html.haml
+++ b/app/views/appointments/new.html.haml
@@ -1,4 +1,4 @@
 %h1= t('appointments.new.title')
 
 %aside#progress
-  Flat 1, 8 Hoxton Square, N1 6NU
+  = @selected_answers['short_address']

--- a/app/views/appointments/new.html.haml
+++ b/app/views/appointments/new.html.haml
@@ -1,0 +1,4 @@
+%h1= t('appointments.new.title')
+
+%aside#progress
+  Flat 1, 8 Hoxton Square, N1 6NU

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,8 @@
 
     %main
       #content{ role: 'main' }
+        - flash.each do |key, value|
+          = content_tag :div, value, class: "flash flash-#{key}"
         = yield
 
     %footer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   address_search:
+    change: Change
     not_found: No addresses found
   appointments:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,9 @@ en:
   address_search:
     change: Change
     not_found: No addresses found
+  addresses:
+    errors:
+      blank: Please choose your address to continue
   appointments:
     new:
       title: Book a repair appointment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,11 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+  appointments:
+    new:
+      title: Book a repair appointment
+  helpers:
+    submit:
+      address:
+        create: Use this address
+      address_search:
+        create: Find my address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,7 @@
 ---
 en:
+  address_search:
+    not_found: No addresses found
   appointments:
     new:
       title: Book a repair appointment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  resource :address_search, only: %i[show update]
-  resource :addresses, only: [:update]
+  resource :address_search, only: %i[new create]
+  resource :address, only: [:create]
   resources :appointments, only: [:new]
 
   root to: 'start#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resource :address_search, only: :show
+  resource :address_search, only: %i[show update]
   resource :addresses, only: [:update]
   resources :appointments, only: [:new]
 

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -60,7 +60,16 @@ RSpec.feature 'Resident can locate a problem' do
   scenario 'when an invalid postcode is entered' do
     visit '/address_search/'
 
-    fill_in :address_search_postcode, with: ' '
+    fill_in :address_search_postcode, with: 'NNN1 1AAA'
+    click_button t('helpers.submit.address_search.create')
+
+    expect(page).to have_content "Postcode doesn't seem to be valid"
+  end
+
+  scenario 'when no postcode is entered' do
+    visit '/address_search/'
+
+    fill_in :address_search_postcode, with: '  '
     click_button t('helpers.submit.address_search.create')
 
     expect(page).to have_content "Postcode can't be blank"

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -91,7 +91,31 @@ RSpec.feature 'Resident can locate a problem' do
     expect(page).to have_content('N1 6NU')
   end
 
-  scenario 'performing a search, but not selecting any address' do
+  scenario 'performing a search and not selecting an address, prevents form submission', js: true do
+    matching_property = {
+      'property_reference' => 'abc123',
+      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+    }
+
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([matching_property])
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/address_search/'
+
+    fill_in :address_search_postcode, with: 'N1 6NU'
+    click_button t('helpers.submit.address_search.create')
+
+    expect(page).to have_no_button t('helpers.submit.address.create')
+
+    within '#address-search-results' do
+      choose 'Flat 1, 8 Hoxton Square, N1 6NU'
+    end
+
+    expect(page).to have_button t('helpers.submit.address.create')
+  end
+
+  scenario 'performing a search and not selecting an address' do
     matching_property = {
       'property_reference' => 'abc123',
       'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Resident can locate a problem' do
   scenario 'viewing the address search form' do
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     expect(page).to have_no_css('#address-search-results')
   end
@@ -24,7 +24,7 @@ RSpec.feature 'Resident can locate a problem' do
     allow(fake_api).to receive(:get).with('properties/abc123').and_return(tenant_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     fill_in :address_search_postcode, with: 'N1 6NU'
     click_button t('helpers.submit.address_search.create')
@@ -47,7 +47,7 @@ RSpec.feature 'Resident can locate a problem' do
     allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     fill_in :address_search_postcode, with: 'N1 6NU'
     click_button t('helpers.submit.address_search.create')
@@ -58,7 +58,7 @@ RSpec.feature 'Resident can locate a problem' do
   end
 
   scenario 'when an invalid postcode is entered' do
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     fill_in :address_search_postcode, with: 'NNN1 1AAA'
     click_button t('helpers.submit.address_search.create')
@@ -67,7 +67,7 @@ RSpec.feature 'Resident can locate a problem' do
   end
 
   scenario 'when no postcode is entered' do
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     fill_in :address_search_postcode, with: '  '
     click_button t('helpers.submit.address_search.create')
@@ -76,14 +76,14 @@ RSpec.feature 'Resident can locate a problem' do
   end
 
   scenario 'changing the postcode after searching' do
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     fill_in :address_search_postcode, with: 'N1 6AA'
     click_button t('helpers.submit.address_search.create')
 
     expect(page).to have_content('N1 6AA')
 
-    click_button t('address_search.change')
+    click_link t('address_search.change')
 
     fill_in :address_search_postcode, with: 'N1 6NU'
     click_button t('helpers.submit.address_search.create')
@@ -101,7 +101,7 @@ RSpec.feature 'Resident can locate a problem' do
     allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([matching_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     fill_in :address_search_postcode, with: 'N1 6NU'
     click_button t('helpers.submit.address_search.create')
@@ -125,7 +125,7 @@ RSpec.feature 'Resident can locate a problem' do
     allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([matching_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
-    visit '/address_search/'
+    visit '/address_search/new/'
 
     fill_in :address_search_postcode, with: 'N1 6NU'
     click_button t('helpers.submit.address_search.create')

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.feature 'Resident can locate a problem' do
   scenario 'when they are a Hackney Council Tenant' do
+    properties = [
+      { 'property_reference' => 'abc123', 'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU' },
+    ]
+    fake_api = double(list_properties: properties)
+    allow(HackneyApi).to receive(:new).and_return(fake_api)
+
     visit '/address_search/'
 
     fill_in :address_search_postcode, with: 'N1 6NU'

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -56,4 +56,13 @@ RSpec.feature 'Resident can locate a problem' do
       expect(page).to have_content t('address_search.not_found')
     end
   end
+
+  scenario 'when an invalid postcode is entered' do
+    visit '/address_search/'
+
+    fill_in :address_search_postcode, with: ' '
+    click_button t('helpers.submit.address_search.create')
+
+    expect(page).to have_content "Postcode can't be blank"
+  end
 end

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -90,4 +90,23 @@ RSpec.feature 'Resident can locate a problem' do
 
     expect(page).to have_content('N1 6NU')
   end
+
+  scenario 'performing a search, but not selecting any address' do
+    matching_property = {
+      'property_reference' => 'abc123',
+      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+    }
+
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([matching_property])
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/address_search/'
+
+    fill_in :address_search_postcode, with: 'N1 6NU'
+    click_button t('helpers.submit.address_search.create')
+    click_button t('helpers.submit.address.create')
+
+    expect(page).to have_content('Please choose your address to continue')
+  end
 end

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -131,6 +131,6 @@ RSpec.feature 'Resident can locate a problem' do
     click_button t('helpers.submit.address_search.create')
     click_button t('helpers.submit.address.create')
 
-    expect(page).to have_content('Please choose your address to continue')
+    expect(page).to have_content(t('addresses.errors.blank'))
   end
 end

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -41,4 +41,19 @@ RSpec.feature 'Resident can locate a problem' do
       expect(page).to have_content 'Flat 1, 8 Hoxton Square, N1 6NU'
     end
   end
+
+  scenario "when the address couldn't be found" do
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([])
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/address_search/'
+
+    fill_in :address_search_postcode, with: 'N1 6NU'
+    click_button t('helpers.submit.address_search.create')
+
+    within '#address-search-results' do
+      expect(page).to have_content t('address_search.not_found')
+    end
+  end
 end

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -1,12 +1,19 @@
 require 'rails_helper'
 
 RSpec.feature 'Resident can locate a problem' do
+  scenario 'viewing the address search form' do
+    visit '/address_search/'
+
+    expect(page).to have_no_css('#address-search-results')
+  end
+
   scenario 'when they are a Hackney Council Tenant' do
     properties = [
       { 'property_reference' => 'abc123', 'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU' },
     ]
-    fake_api = double(list_properties: properties)
-    allow(HackneyApi).to receive(:new).and_return(fake_api)
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return(properties)
+    allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address_search/'
 

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -74,4 +74,20 @@ RSpec.feature 'Resident can locate a problem' do
 
     expect(page).to have_content "Postcode can't be blank"
   end
+
+  scenario 'changing the postcode after searching' do
+    visit '/address_search/'
+
+    fill_in :address_search_postcode, with: 'N1 6AA'
+    click_button t('helpers.submit.address_search.create')
+
+    expect(page).to have_content('N1 6AA')
+
+    click_button 'Change'
+
+    fill_in :address_search_postcode, with: 'N1 6NU'
+    click_button t('helpers.submit.address_search.create')
+
+    expect(page).to have_content('N1 6NU')
+  end
 end

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -8,11 +8,20 @@ RSpec.feature 'Resident can locate a problem' do
   end
 
   scenario 'when they are a Hackney Council Tenant' do
-    properties = [
-      { 'property_reference' => 'abc123', 'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU' },
-    ]
+    tenant_property = {
+      'property_reference' => 'abc123',
+      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+    }
+    other_property = {
+      'property_reference' => 'def456',
+      'short_address' => 'Flat 7, 12 Hoxton Square, N1 6NU',
+    }
+
+    matching_properties = [other_property, tenant_property]
+
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return(properties)
+    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return(matching_properties)
+    allow(fake_api).to receive(:get).with('properties/abc123').and_return(tenant_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address_search/'

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Resident can locate a problem' do
 
     expect(page).to have_content('N1 6AA')
 
-    click_button 'Change'
+    click_button t('address_search.change')
 
     fill_in :address_search_postcode, with: 'N1 6NU'
     click_button t('helpers.submit.address_search.create')

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.feature 'Resident can locate a problem' do
+  scenario 'when they are a Hackney Council Tenant' do
+    visit '/address_search/'
+
+    fill_in :address_search_postcode, with: 'N1 6NU'
+    click_button t('helpers.submit.address_search.create')
+
+    within '#address-search-results' do
+      choose 'Flat 1, 8 Hoxton Square, N1 6NU'
+    end
+
+    click_button t('helpers.submit.address.create')
+
+    expect(page).to have_content t('appointments.new.title')
+
+    within '#progress' do
+      expect(page).to have_content 'Flat 1, 8 Hoxton Square, N1 6NU'
+    end
+  end
+end

--- a/spec/models/address_search_spec.rb
+++ b/spec/models/address_search_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require 'active_model'
+require 'app/models/address_search'
+
+RSpec.describe AddressSearch do
+  describe '.data' do
+    it 'returns the search data as a hash' do
+      params = { postcode: 'N16 8QR' }
+      expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
+    end
+  end
+end

--- a/spec/models/address_search_spec.rb
+++ b/spec/models/address_search_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe AddressSearch do
       expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
     end
 
+    it 'adds a space in the middle' do
+      params = { postcode: 'N168QR' }
+      expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
+    end
+
     it 'converts postcodes to upper case' do
       params = { postcode: 'n16 8qr' }
       expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')

--- a/spec/models/address_search_spec.rb
+++ b/spec/models/address_search_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe AddressSearch do
       params = { postcode: 'N16 8QR' }
       expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
     end
+
+    it 'strips surrounding whitespace on postcodes' do
+      params = { postcode: " \t  N16 8QR   " }
+      expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
+    end
+
+    it 'strips extra internal spaces in postcodes' do
+      params = { postcode: 'N16   8QR' }
+      expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
+    end
+
+    it 'converts postcodes to upper case' do
+      params = { postcode: 'n16 8qr' }
+      expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
+    end
   end
 
   describe 'Validations' do

--- a/spec/models/address_search_spec.rb
+++ b/spec/models/address_search_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'active_model'
+require 'app/validators/postcode_validator'
 require 'app/models/address_search'
 
 RSpec.describe AddressSearch do
@@ -7,6 +8,76 @@ RSpec.describe AddressSearch do
     it 'returns the search data as a hash' do
       params = { postcode: 'N16 8QR' }
       expect(AddressSearch.new(params).data).to eq(postcode: 'N16 8QR')
+    end
+  end
+
+  describe 'Validations' do
+    valid_postcodes = [
+      'N16 8QR',
+      'N1 3ND',
+      'E8 1DT',
+      'N1 6NU',
+    ]
+    valid_postcodes.each do |postcode|
+      it "is valid when the postcode is #{postcode}" do
+        expect(AddressSearch.new(postcode: postcode)).to be_valid
+      end
+    end
+
+    it 'is valid for a lowercase postcode' do
+      expect(AddressSearch.new(postcode: 'n16 8qr')).to be_valid
+    end
+
+    it 'is valid for a mixed-case postcode' do
+      expect(AddressSearch.new(postcode: 'N16 8Qr')).to be_valid
+    end
+
+    it 'is valid with no spaces in the postcode' do
+      expect(AddressSearch.new(postcode: 'N168QR')).to be_valid
+    end
+
+    it 'is valid with extra spaces in the middle of the postcode' do
+      expect(AddressSearch.new(postcode: 'N16   8QR')).to be_valid
+    end
+
+    it 'is invalid when the postcode has random internal spaces' do
+      # NOTE: this is what the regex gives us - not necessarily what we want
+      address_search = AddressSearch.new(postcode: 'N 16 8QR')
+      address_search.valid?
+      expect(address_search.errors.full_messages).to include("Postcode doesn't seem to be valid")
+    end
+
+    it 'is invalid for a missing postcode' do
+      address_search = AddressSearch.new({})
+      address_search.valid?
+      expect(address_search.errors.full_messages).to include("Postcode can't be blank")
+    end
+
+    it 'is invalid for an empty postcode' do
+      address_search = AddressSearch.new(postcode: "   \t")
+      address_search.valid?
+      expect(address_search.errors.full_messages).to include("Postcode can't be blank")
+    end
+
+    it 'only shows one validation error for an empty postcode' do
+      address_search = AddressSearch.new(postcode: "   \t")
+      address_search.valid?
+      expect(address_search.errors[:postcode]).to eq ["can't be blank"]
+    end
+
+    invalid_postcodes = [
+      'A',
+      'AAA AAA',
+      'N16',
+      'N16 8Q',
+      'N8 QR',
+    ]
+    invalid_postcodes.each do |postcode|
+      it "is invalid when the postcode is #{postcode}" do
+        address_search = AddressSearch.new(postcode: postcode)
+        address_search.valid?
+        expect(address_search.errors.full_messages).to include("Postcode doesn't seem to be valid")
+      end
     end
   end
 end

--- a/spec/models/selected_answer_store_spec.rb
+++ b/spec/models/selected_answer_store_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'app/models/selected_answer_store'
+
+RSpec.describe SelectedAnswerStore do
+  it 'should store answers for a given stage' do
+    session = {}
+    answers = {
+      'property_ref' => 'bsg108',
+    }
+    store = SelectedAnswerStore.new(session)
+
+    store.store_selected_answers('address', answers)
+
+    expect(session[:selected_answers]).to eql('address' => answers)
+    expect(store.selected_answers).to eql('address' => answers)
+  end
+
+  it 'should overwrite stale answers with new ones' do
+    session = {}
+    old_answers = {
+      'property_ref' => 'adh389',
+      'address' => 'Flat 1, 35 Church Walk, N16 8QR',
+    }
+    new_answers = {
+      'property_ref' => 'bsg108',
+    }
+
+    store = SelectedAnswerStore.new(session)
+    store.store_selected_answers('address', old_answers)
+    store.store_selected_answers('address', new_answers)
+
+    expect(session[:selected_answers]).to eql('address' => new_answers)
+    expect(store.selected_answers).to eql('address' => new_answers)
+  end
+end

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -4,7 +4,9 @@ require 'app/queries/address_finder'
 RSpec.describe AddressFinder do
   describe '.find' do
     it 'returns some hardcoded data' do
-      expect(AddressFinder.new.find(double)).to eq [['P01234', 'Flat 1, 8 Hoxton Square, N1 6NU']]
+      result = AddressFinder.new.find(double)
+      expect(result.first.property_reference).to eq 'P01234'
+      expect(result.first.short_address).to eq 'Flat 1, 8 Hoxton Square, N1 6NU'
     end
   end
 end

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -3,8 +3,27 @@ require 'app/queries/address_finder'
 
 RSpec.describe AddressFinder do
   describe '.find' do
-    it 'returns some hardcoded data' do
-      result = AddressFinder.new.find(double)
+    it 'calls out to an api' do
+      api = spy
+      form = double(data: { postcode: 'N1 6NU' })
+
+      AddressFinder.new(api).find(form)
+
+      expect(api).to have_received(:list_properties).with('N1 6NU')
+    end
+
+    it 'wraps the result of the api call in an object' do
+      api_result = [
+        {
+          'property_reference' => 'P01234',
+          'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+        },
+      ]
+      api = double(list_properties: api_result)
+      form = double(data: { postcode: 'N1 6NU' })
+
+      result = AddressFinder.new(api).find(form)
+
       expect(result.first.property_reference).to eq 'P01234'
       expect(result.first.short_address).to eq 'Flat 1, 8 Hoxton Square, N1 6NU'
     end

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AddressFinder do
 
       AddressFinder.new(api).find(form)
 
-      expect(api).to have_received(:list_properties).with('N1 6NU')
+      expect(api).to have_received(:list_properties).with(postcode: 'N1 6NU')
     end
 
     it 'wraps the result of the api call in an object' do

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'app/queries/address_finder'
+
+RSpec.describe AddressFinder do
+  describe '.find' do
+    it 'returns some hardcoded data' do
+      expect(AddressFinder.new.find(double)).to eq [['P01234', 'Flat 1, 8 Hoxton Square, N1 6NU']]
+    end
+  end
+end

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+require 'app/queries/hackney_api'
+
+describe HackneyApi do
+end

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -2,4 +2,15 @@ require 'spec_helper'
 require 'app/queries/hackney_api'
 
 describe HackneyApi do
+  describe '#list_properties' do
+    it 'returns a list of properties' do
+      results = [
+        { 'property_reference' => 'def567', 'short_address' => 'Flat 8, 1 Aardvark Road, A1 1AA' },
+      ]
+      json_api = double(get: results)
+      api = HackneyApi.new(json_api)
+
+      expect(api.list_properties(postcode: 'A1 1AA')).to eql results
+    end
+  end
 end

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -13,4 +13,18 @@ describe HackneyApi do
       expect(api.list_properties(postcode: 'A1 1AA')).to eql results
     end
   end
+
+  describe '#get_property' do
+    it 'returns an individual property' do
+      results = {
+        'property_reference' => 'cre045',
+        'short_address' => 'Flat 45, Cheddar Row Estate, Hackney, N1 1AA',
+      }
+      json_api = instance_double('JsonApi')
+      allow(json_api).to receive(:get).with('properties/cre045').and_return(results)
+      api = HackneyApi.new(json_api)
+
+      expect(api.get_property(property_reference: 'cre045')).to eql results
+    end
+  end
 end

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'app/queries/json_api'
+
+RSpec.describe JsonApi do
+  describe '#get' do
+    it 'does not raise an error' do
+      json_api = JsonApi.new
+
+      expect { json_api.get('asfasf') }.not_to raise_error
+    end
+
+    it 'returns a fixed response' do
+      json_api = JsonApi.new
+
+      results = [
+        { 'property_reference' => 'zxc987', 'short_address' => '221B Aardvark Road, A1 1AA' },
+      ]
+
+      expect(json_api.get('not/a/real/path')).to eq(results)
+    end
+  end
+end

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -9,14 +9,26 @@ RSpec.describe JsonApi do
       expect { json_api.get('asfasf') }.not_to raise_error
     end
 
-    it 'returns a fixed response' do
-      json_api = JsonApi.new
+    context 'with a path matching properties?postcode=' do
+      it 'returns a valid response' do
+        json_api = JsonApi.new
 
-      results = [
-        { 'property_reference' => 'zxc987', 'short_address' => '221B Aardvark Road, A1 1AA' },
-      ]
+        result = json_api.get('properties?postcode=A1 1AA')
 
-      expect(json_api.get('not/a/real/path')).to eq(results)
+        expect(result).to be_an(Array)
+        expect(result.first.keys).to include('property_reference', 'short_address')
+      end
+    end
+
+    context 'with a path matching properties/:property_reference' do
+      it 'returns a valid response' do
+        json_api = JsonApi.new
+
+        result = json_api.get('properties/zxc098')
+
+        expect(result).to be_a(Hash)
+        expect(result.keys).to include('property_reference', 'short_address', 'uprn')
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 SimpleCov.start 'rails' do
   add_group 'Queries', 'app/queries'
+  add_group 'Validators', 'app/validators'
 end
 
 require 'spec_helper'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,8 @@ end
 
 require 'rspec/rails'
 require 'capybara/rspec'
+require 'capybara/poltergeist'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -35,6 +37,8 @@ require 'capybara/rspec'
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+
+Capybara.javascript_driver = :poltergeist
 
 RSpec.configure do |config|
   config.include AbstractController::Translation


### PR DESCRIPTION
A resident can visit `/address_search/` and enter their postcode. If it is in the correct format, they are shown a list of matching addresses.

If they have JavaScript enabled, the submit buttons are hidden until they select an address from the list. 

This is a first attempt at this, and will need revisiting in the future (clicking back button, shows radio button previously selected, but the submit button is still hidden, for example). I'm suspecting this should be some standalone JS tests (perhaps using `jasmine-rails`), as this behaviour should be decoupled from the app.

NB: Currently this entirely returns canned responses in place of the API, which is still being built.