### PR TITLE
(98) Style address selection

### DIFF
--- a/app/assets/stylesheets/hackney.scss
+++ b/app/assets/stylesheets/hackney.scss
@@ -60,6 +60,10 @@ main {
     @extend %site-width-container;
   }
 
+  strong {
+    font-weight: bold;
+  }
+
   h1 {
     @include heading-48;
 

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -9,8 +9,14 @@
   #address-search-results
     - if @address_search_results.any?
       = simple_form_for @address, url: address_path do |f|
-        = f.collection_radio_buttons :property_reference, @address_search_results, :property_reference, :short_address
-        = f.button :submit
+        = f.input :property_reference,
+          as: :radio_buttons,
+          collection: @address_search_results,
+          label_method: :short_address,
+          value_method: :property_reference,
+          label: false
+
+        = f.button :submit, class: 'button'
     - else
       = t('address_search.not_found')
 

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -1,22 +1,28 @@
+%h1
+  What is your address?
+
 - if @address_search.errors
   = @address_search.errors.full_messages.join(', ')
 
-%p
-  = @address_search.postcode
+%p.form-label
+  Postcode
+  %br/
+  %strong
+    = @address_search.postcode.upcase
   = link_to t('address_search.change'), new_address_search_path
 
 - if @address_search_results
   #address-search-results
     - if @address_search_results.any?
       = simple_form_for @address, url: address_path do |f|
-        = f.input :property_reference,
-          as: :radio_buttons,
-          collection: @address_search_results,
-          label_method: :short_address,
-          value_method: :property_reference,
-          label: false
+        %fieldset
+          = f.input :property_reference,
+            as: :radio_buttons,
+            collection: @address_search_results,
+            label_method: :short_address,
+            value_method: :property_reference
 
-        = f.button :submit, class: 'button'
+          = f.button :submit, class: 'button'
     - else
       = t('address_search.not_found')
 

--- a/app/views/address_searches/new.html.haml
+++ b/app/views/address_searches/new.html.haml
@@ -1,7 +1,11 @@
+%h1
+  What is your address?
+
 - if @address_search.errors
   = @address_search.errors.full_messages.join(', ')
 
 = simple_form_for @address_search, url: address_search_path do |f|
-  = f.input :postcode
-  = f.button :submit
+  %fieldset
+    = f.input :postcode
+    = f.button :submit, class: 'button'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,10 @@ en:
         create: Find my address
       create: Continue
   simple_form:
+    labels:
+      address:
+        new:
+          property_reference: Select your address
     options:
       start_form:
         priority_repair:

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Resident can locate a problem' do
     click_button t('helpers.submit.address_search.create')
 
     within '#address-search-results' do
-      choose 'Flat 1, 8 Hoxton Square, N1 6NU'
+      choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
     end
 
     click_button t('helpers.submit.address.create')
@@ -114,7 +114,7 @@ RSpec.feature 'Resident can locate a problem' do
     expect(page).to have_no_button t('helpers.submit.address.create')
 
     within '#address-search-results' do
-      choose 'Flat 1, 8 Hoxton Square, N1 6NU'
+      choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
     end
 
     expect(page).to have_button t('helpers.submit.address.create')

--- a/spec/features/users_can_answer_repair_questions_spec.rb
+++ b/spec/features/users_can_answer_repair_questions_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Users can answer repair questions' do
 
   scenario "Users can choose 'Yes' and get shown the emergency contact page" do
     visit '/questions/start/'
-    choose t('simple_form.options.start_form.priority_repair.yes')
+    choose_radio_button t('simple_form.options.start_form.priority_repair.yes')
     click_continue
 
     expect(page).to have_content 'Please call our repair centre'
@@ -35,7 +35,7 @@ RSpec.feature 'Users can answer repair questions' do
 
   scenario "Users can choose 'No' and is shown the next question" do
     visit '/questions/start/'
-    choose t('simple_form.options.start_form.priority_repair.no')
+    choose_radio_button t('simple_form.options.start_form.priority_repair.no')
     click_continue
 
     within '.question' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,7 @@ require 'capybara/poltergeist'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -69,4 +69,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include CapybaraHelpers, type: :feature
 end

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -1,0 +1,5 @@
+module CapybaraHelpers
+  def choose_radio_button(label)
+    find(:label, text: label).click
+  end
+end


### PR DESCRIPTION
The radio buttons for address selection are now rendered in the correct styling.

**NB: This branch is currently based off #5, as that branch includes the relevant CSS radio button styles from GOVUK elements.**

## Before
<img width="675" alt="before" src="https://user-images.githubusercontent.com/3166/30965903-ec425752-a44e-11e7-91c5-dac66a3ec0a9.png">

## After
<img width="318" alt="after" src="https://user-images.githubusercontent.com/3166/30965902-ec3e503a-a44e-11e7-9f08-6a356537711b.png">
