### PR TITLE
(45) Unidentified addresses directed to call centre

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -7,6 +7,10 @@ class AddressesController < ApplicationController
       )
     end
 
+    if property_reference == 'address_isnt_here'
+      return redirect_to address_isnt_here_path
+    end
+
     api = HackneyApi.new
     address = api.get_property(property_reference: property_reference)
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
 class PagesController < ApplicationController
+  def address_isnt_here; end
+
   def emergency_contact; end
 end

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -20,7 +20,14 @@
             as: :radio_buttons,
             collection: @address_search_results,
             label_method: :short_address,
-            value_method: :property_reference
+            value_method: :property_reference,
+            label: false
+
+          = f.input :property_reference,
+            as: :radio_buttons,
+            collection: [:address_isnt_here],
+            label: false,
+            include_hidden: false
 
           = f.button :submit, class: 'button'
     - else

--- a/app/views/pages/address_isnt_here.html.haml
+++ b/app/views/pages/address_isnt_here.html.haml
@@ -1,0 +1,13 @@
+%h1
+  We cannot find your address
+
+%p.lede
+  This might be because your home is not managed by Hackney Council.
+
+%p
+  If you are one of our tenants, please call our repair centre on
+  %a{ href: 'tel:02083563691' } 020 8356 3691
+  so we can help you with your problem.
+
+%p
+  We are open Monday to Friday 8am - 7pm and Saturdays 9am - 1pm.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,9 @@ en:
         new:
           property_reference: Select your address
     options:
+      address:
+        property_reference:
+          address_isnt_here: "My address isn't here"
       start_form:
         priority_repair:
           'yes': 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,9 @@ Rails.application.routes.draw do
       to: 'pages#emergency_contact',
       as: 'emergency_contact'
 
+  get '/address-isnt-here',
+      to: 'pages#address_isnt_here',
+      as: 'address_isnt_here'
+
   root to: 'start#index'
 end

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Resident can locate a problem' do
     end
   end
 
-  scenario "when the address couldn't be found" do
+  scenario 'when the address search returned no results' do
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([])
     allow(JsonApi).to receive(:new).and_return(fake_api)
@@ -137,5 +137,29 @@ RSpec.feature 'Resident can locate a problem' do
     click_button t('helpers.submit.address.create')
 
     expect(page).to have_content(t('addresses.errors.blank'))
+  end
+
+  scenario "user's address isn't listed" do
+    other_property = {
+      'property_reference' => 'abc123',
+      'short_address' => '99 Abersham Road',
+    }
+
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([other_property])
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/address_search/new/'
+
+    fill_in :address_search_postcode, with: 'N1 6NU'
+    click_button t('helpers.submit.address_search.create')
+
+    within '#address-search-results' do
+      choose_radio_button t('simple_form.options.address.property_reference.address_isnt_here')
+    end
+
+    click_button t('helpers.submit.address.create')
+
+    expect(page).to have_content 'We cannot find your address'
   end
 end


### PR DESCRIPTION
When the resident cannot see their address in the address lookup search results, give them the option to choose "My address isn't here". When the form is submitted, they are sent to a page that asks them to call Hackney.

<img width="921" alt="cannot-find-address" src="https://user-images.githubusercontent.com/3166/31022370-8227133e-a530-11e7-8b3d-0e98e3cb63e2.png">

**NB: This relies on #6, which should be merged first**