### PR TITLE
(79) Problem description page (known)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,39 +11,6 @@
  * It is generally better to create a new file per style scope.
  *
  *= require_self
- *= require_tree .
+ *= require hackney
  */
 
-@import 'variables';
-
-/* From GDS's alphagov/govuk_frontend_toolkit */
-@import 'font_stack';
-@import 'measurements';
-@import 'conditionals';
-@import 'device-pixels';
-@import 'grid_layout';
-@import 'typography';
-@import 'shims';
-
-@import 'design-patterns/alpha-beta';
-@import 'design-patterns/buttons';
-@import 'design-patterns/breadcrumbs';
-
-/* From GDS's alphagov/govuk_elements */
-@import 'elements/helpers';
-@import 'elements/reset';
-@import 'elements/layout';
-@import 'elements/elements-typography';
-@import 'elements/buttons';
-@import 'elements/icons';
-@import 'elements/lists';
-// @import 'elements/tables';
-// @import 'elements/details';
-// @import 'elements/panels';
-@import 'elements/forms';
-@import 'elements/forms/form-multiple-choice';
-// @import 'elements/forms/form-date';
-@import 'elements/forms/form-validation';
-@import 'elements/breadcrumbs';
-@import 'elements/phase-banner';
-@import 'elements/components';

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,0 +1,43 @@
+footer {
+  background-color: $hackney-dark-grey;
+  border-top: 5px solid $hackney-green;
+  color: $white;
+  font-size: 14px;
+  padding: 2em;
+  position: relative;
+
+  &::before, &::after {
+    background-color: $hackney-light-green;
+    content: '';
+    display: block;
+    height: 3px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 5px;
+  }
+
+  a {
+    color: $white;
+    padding: 7px;
+    text-decoration: none;
+    text-transform: uppercase;
+
+    &:link, &:visited, &:active, &:hover, &:focus {
+      color: $white;
+    }
+
+    &:hover, &:focus {
+      text-decoration: underline;
+    }
+
+    &:focus {
+      color: $black;
+    }
+  }
+
+  ul {
+    padding: 1em 0;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -1,0 +1,26 @@
+.question {
+  padding-bottom: 30px;
+}
+
+.radio {
+  @extend .multiple-choice;
+}
+
+textarea {
+  @extend .form-control;
+
+  width: 100%;
+  height: 10em;
+}
+
+input.string {
+  @extend .form-control;
+}
+
+.button {
+  background-color: $hackney-green;
+
+  &:hover, &:focus {
+    background-color: $hackney-light-green;
+  }
+}

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,0 +1,34 @@
+header {
+  background-color: $hackney-dark-grey;
+  border-bottom: 4px solid $hackney-green;
+  color: $white;
+  padding: 1em;
+
+  h1 {
+    background: asset-url('logo.png') 0 0 no-repeat;
+    display: inline-block;
+    height: 54px;
+    overflow: hidden;
+    text-indent: 100%;
+    vertical-align: middle;
+    white-space: nowrap;
+    width: 300px;
+  }
+
+  a, a:link, a:visited, a:hover {
+    background-color: $hackney-dark-grey;
+    color: $white;
+    text-decoration: none;
+  }
+
+  h2 {
+    @include heading-24;
+    display: inline-block;
+    margin-left: 1em;
+    vertical-align: middle;
+
+    @include media(mobile) {
+      margin-left: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/main.scss
+++ b/app/assets/stylesheets/components/main.scss
@@ -1,0 +1,29 @@
+main {
+  background-color: $white;
+  padding: 1em 0;
+
+  #main-content {
+    @extend %site-width-container;
+  }
+
+  strong {
+    font-weight: bold;
+  }
+
+  h1 {
+    @include heading-36;
+
+    color: $hackney-green;
+    font-weight: bold;
+  }
+
+  h2 {
+    @include heading-24;
+  }
+
+  ul {
+    list-style-type: disc;
+    padding-left: 20px;
+  }
+}
+

--- a/app/assets/stylesheets/hackney.scss
+++ b/app/assets/stylesheets/hackney.scss
@@ -65,14 +65,14 @@ main {
   }
 
   h1 {
-    @include heading-48;
+    @include heading-36;
 
     color: $hackney-green;
     font-weight: bold;
   }
 
   h2 {
-    @include heading-36;
+    @include heading-24;
   }
 
   ul {
@@ -86,6 +86,14 @@ main {
 
   .radio {
     @extend .multiple-choice;
+  }
+
+  textarea.text {
+    @extend .form-control;
+  }
+
+  input.string {
+    @extend .form-control;
   }
 
   .button {

--- a/app/assets/stylesheets/hackney.scss
+++ b/app/assets/stylesheets/hackney.scss
@@ -1,11 +1,43 @@
 @import 'variables';
+
+/* From GDS's alphagov/govuk_frontend_toolkit */
+@import 'font_stack';
+@import 'measurements';
+@import 'conditionals';
+@import 'device-pixels';
 @import 'grid_layout';
 @import 'typography';
+@import 'shims';
 
-@import 'colours/palette';
+@import 'design-patterns/alpha-beta';
+@import 'design-patterns/buttons';
+@import 'design-patterns/breadcrumbs';
 
+/* From GDS's alphagov/govuk_elements */
+@import 'elements/govuk-template-base';
+@import 'elements/helpers';
+@import 'elements/reset';
+@import 'elements/layout';
+@import 'elements/elements-typography';
+@import 'elements/buttons';
+@import 'elements/icons';
+@import 'elements/lists';
 @import 'elements/forms';
 @import 'elements/forms/form-multiple-choice';
+@import 'elements/forms/form-validation';
+@import 'elements/breadcrumbs';
+@import 'elements/phase-banner';
+@import 'elements/components';
+
+/* Include our components */
+@import 'components/header';
+@import 'components/main';
+@import 'components/footer';
+@import 'components/forms';
+
+html {
+  background-color: $hackney-dark-grey;
+}
 
 body {
   background-color: $hackney-dark-grey;
@@ -18,125 +50,3 @@ body {
   @extend %site-width-container;
 }
 
-header {
-  background-color: $hackney-dark-grey;
-  border-bottom: 4px solid $hackney-green;
-  color: $white;
-  padding: 1em;
-
-  h1 {
-    background: asset-url('logo.png') 0 0 no-repeat;
-    display: inline-block;
-    height: 54px;
-    overflow: hidden;
-    text-indent: 100%;
-    vertical-align: middle;
-    white-space: nowrap;
-    width: 300px;
-  }
-
-  a {
-    color: $white;
-    text-decoration: none;
-  }
-
-  h2 {
-    @include heading-24;
-    display: inline-block;
-    margin-left: 1em;
-    vertical-align: middle;
-
-    @include media(mobile) {
-      margin-left: 0;
-    }
-  }
-}
-
-main {
-  background-color: $white;
-  padding: 1em 0;
-
-  #main-content {
-    @extend %site-width-container;
-  }
-
-  strong {
-    font-weight: bold;
-  }
-
-  h1 {
-    @include heading-36;
-
-    color: $hackney-green;
-    font-weight: bold;
-  }
-
-  h2 {
-    @include heading-24;
-  }
-
-  ul {
-    list-style-type: disc;
-    padding-left: 20px;
-  }
-
-  .question {
-    padding-bottom: 30px;
-  }
-
-  .radio {
-    @extend .multiple-choice;
-  }
-
-  textarea.text {
-    @extend .form-control;
-  }
-
-  input.string {
-    @extend .form-control;
-  }
-
-  .button {
-    background-color: $hackney-green;
-
-    &:hover, &:focus {
-      background-color: $hackney-light-green;
-    }
-  }
-}
-
-footer {
-  background-color: $hackney-dark-grey;
-  border-top: 5px solid $hackney-green;
-  color: $white;
-  font-size: 14px;
-  padding: 2em;
-  position: relative;
-
-  a {
-    color: $white;
-    padding: 7px;
-    text-decoration: none;
-    text-transform: uppercase;
-
-    &:hover, &:focus {
-      text-decoration: underline;
-    }
-  }
-
-  ul {
-    padding: 1em 0;
-    text-align: center;
-  }
-
-  &::before, &::after {
-    background-color: $hackney-light-green;
-    content: '';
-    display: block;
-    height: 3px;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 5px;
-  }
-}

--- a/app/controllers/describe_repair_controller.rb
+++ b/app/controllers/describe_repair_controller.rb
@@ -1,0 +1,7 @@
+class DescribeRepairController < ApplicationController
+  def index; end
+
+  def submit
+    redirect_to new_address_search_path
+  end
+end

--- a/app/views/describe_repair/index.html.haml
+++ b/app/views/describe_repair/index.html.haml
@@ -1,0 +1,15 @@
+= simple_form_for :dummy_form, url: request.fullpath do |f|
+  %fieldset
+    %legend.question
+      %h1 Is there anything else we should know about this problem?
+
+      %p
+        For example:
+
+      %ul
+        %li which rooms are affected?
+        %li how does it impact your household?
+
+    .answers
+      = f.input :description, as: :text, label: false
+      = f.button :submit, class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,8 @@ en:
       address_search:
         create: Find my address
       create: Continue
+      dummy_form:
+        submit: Continue
   simple_form:
     labels:
       address:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,8 @@ Rails.application.routes.draw do
       to: 'pages#address_isnt_here',
       as: 'address_isnt_here'
 
+  get '/describe-repair', to: 'describe_repair#index', as: 'describe_repair'
+  post '/describe-repair', to: 'describe_repair#submit'
+
   root to: 'start#index'
 end


### PR DESCRIPTION
Create a dummy form for entering details about the repair.

NB: Anything saved into the form is currently **NOT** persisted. Additionally, submitting the form redirects the user to the address search page.

As part of this branch, I've included the GOVUK focus styles (which highlight the currently-focussed form element) and broken the stylesheet up into smaller parts.

From: `/questions/describe-repair` 

<img width="883" alt="describe-repair" src="https://user-images.githubusercontent.com/3166/31079125-7689b128-a77c-11e7-8ca8-d37ffbff0c07.png">

