### PR TITLE
[104] allow longer methods in controllers

### DIFF
--- a/app/controllers/.rubocop.yml
+++ b/app/controllers/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - ../../.rubocop.yml
+
+Metrics/MethodLength:
+    Max: 15


### PR DESCRIPTION
We in general want our methods to be short, but this is hard to do in
Controllers without prematurely extracting objects and/or mangling the
code.

Rubocop doesn't support specifying different rules for different
directories in the main .rubocop.yml, but additional rubocop.yml files
in directories apply to all the files in and below that directory