### PR TITLE
(80) Problem description page (unknown)

### DIFF
--- a/app/controllers/describe_unknown_repair_controller.rb
+++ b/app/controllers/describe_unknown_repair_controller.rb
@@ -1,0 +1,7 @@
+class DescribeUnknownRepairController < ApplicationController
+  def index; end
+
+  def submit
+    redirect_to new_address_search_path
+  end
+end

--- a/app/views/describe_unknown_repair/index.html.haml
+++ b/app/views/describe_unknown_repair/index.html.haml
@@ -1,0 +1,15 @@
+= simple_form_for :dummy_form, url: request.fullpath do |f|
+  %fieldset
+    %legend.question
+      %h1 Please describe what needs to be fixed
+
+      %p
+        For example:
+
+      %ul
+        %li which rooms are affected?
+        %li how does it impact your household?
+
+    .answers
+      = f.input :description, as: :text, label: false
+      = f.button :submit, class: 'button'

--- a/app/views/questions/start/index.html.haml
+++ b/app/views/questions/start/index.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for @form, url: questions_start_submit_path do |f|
+= simple_form_for @form, url: request.fullpath do |f|
   %fieldset
     %legend.question
       %h1 Is your problem one of these?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   namespace :questions do
     get '/start', to: 'start#index', as: 'start'
-    post '/start', to: 'start#submit', as: 'start_submit'
+    post '/start', to: 'start#submit'
   end
 
   get '/emergency-contact',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,10 @@ Rails.application.routes.draw do
   get '/describe-repair', to: 'describe_repair#index', as: 'describe_repair'
   post '/describe-repair', to: 'describe_repair#submit'
 
+  get '/describe-unknown-repair',
+      to: 'describe_unknown_repair#index',
+      as: 'describe_unknown_repair'
+  post '/describe-unknown-repair', to: 'describe_unknown_repair#submit'
+
   root to: 'start#index'
 end


### PR DESCRIPTION
Add an additional dummy form, similar to the one in #10. This one is for the "problem is something else" path, so the wording is slightly different.

I'd also noticed that the `questions/start` page had slightly different markup to the other forms I've built so far, so I've fixed that here.

From: `/questions/describe-unknown-repair`:

<img width="703" alt="describe-unknown-repair" src="https://user-images.githubusercontent.com/3166/31079316-243f9968-a77d-11e7-8560-4b8f78755224.png">
