### PR TITLE
[82] Confirmation page (dummy)

### DIFF
--- a/app/assets/stylesheets/components/main.scss
+++ b/app/assets/stylesheets/components/main.scss
@@ -19,11 +19,25 @@ main {
 
   h2 {
     @include heading-24;
+
+    font-weight: bold;
+  }
+
+  h3 {
+    font-weight: bold;
   }
 
   ul {
     list-style-type: disc;
     padding-left: 20px;
+  }
+
+  .box-highlight {
+    margin: 1em 0;
+    padding: 2em 1em;
+    color: $white;
+    background-color: $hackney-green;
+    text-align: center;
   }
 }
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,7 @@
+class ConfirmationsController < ApplicationController
+  def show
+    @confirmation = Confirmation.new(params[:id])
+  end
+
+  Confirmation = Struct.new(:repair_request_id)
+end

--- a/app/views/confirmations/show.html.haml
+++ b/app/views/confirmations/show.html.haml
@@ -1,0 +1,44 @@
+.grid-row
+  .column-two-thirds
+    %h1
+      Thank you John Smith
+
+    %p
+      Your repair request has been successfully submitted.
+
+    .box-highlight.lede
+      Your reference number is
+      = succeed "." do
+        %strong= @confirmation.repair_request_id
+
+    %p
+      We will call you within one working day, between
+      %strong 12pm and 5pm
+      to arrange a repair appointment.
+
+    %p
+      %strong
+        If you have any questions, please call us on
+        %span{:itemprop => "telephone"}
+          = link_to "020 8356 3691", "tel:+02083563691"
+      and quote your reference number
+      = succeed "." do
+        %strong= @confirmation.repair_request_id
+      We are open Monday to Friday 8am - 7pm and Saturdays 9am - 1pm.
+
+.grid-row
+  .column-two-thirds
+    %h2 Summary
+
+    %h3 Problem
+    %p Type: Blocked bath
+    %p Description: The bath won't drain
+
+    %h3 Your details
+    %p Name: John Smith
+    %p Phone: 01234 567 890
+    %p Address: Flat 1, 8 Hoxton Square, N1 6NU
+
+    %h3 Callback time
+    %p Time: afternoon, 12pm - 5pm
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resource :address_search, only: %i[new create]
   resource :address, only: [:create]
   resources :appointments, only: [:new]
+  resources :confirmations, only: [:show]
 
   namespace :questions do
     get '/start', to: 'start#index', as: 'start'

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.feature 'Resident can see a confirmation of their repair request' do
+  scenario 'when the repair request creation was successful' do
+    visit '/confirmations/00012143'
+
+    expect(page).to have_content 'Your reference number is 00012143'
+  end
+end


### PR DESCRIPTION
PLEASE CHECK the copy for sanity and that we have the right set of data on this page.

This is mostly hardcoded - except for the repair reference.

Mocked up a Confirmation object as a Struct because I don't want to be
passing 20 individual instance variables to the view ;)

The spec here was just to drive out the routing and controller. When we
have real templates for everything, I anticipate this being a full
end-to-end test which goes through all the screens and checks that the
correct values are shown on the confirmations page.

Need to remember to pull out the phone number to i18n at some point