### PR TITLE
(86) 'Back' links throughout the form

### DIFF
--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -6,11 +6,9 @@ class AddressSearchesController < ApplicationController
 
   def create
     @address_search = AddressSearch.new(address_search_params[:address_search])
+    @back = Back.new(controller_name: 'describe_repair')
 
-    unless @address_search.valid?
-      @back = Back.new(controller_name: 'describe_repair')
-      return render :index
-    end
+    return render :index unless @address_search.valid?
 
     address_finder = AddressFinder.new(HackneyApi.new)
     @address_search_results = address_finder.find(@address_search)

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -1,11 +1,16 @@
 class AddressSearchesController < ApplicationController
   def index
     @address_search = AddressSearch.new
+    @back = Back.new(controller_name: 'describe_repair')
   end
 
   def create
     @address_search = AddressSearch.new(address_search_params[:address_search])
-    return render :index unless @address_search.valid?
+
+    unless @address_search.valid?
+      @back = Back.new(controller_name: 'describe_repair')
+      return render :index
+    end
 
     address_finder = AddressFinder.new(HackneyApi.new)
     @address_search_results = address_finder.find(@address_search)

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -8,6 +8,7 @@ class AddressesController < ApplicationController
       address_finder = AddressFinder.new(HackneyApi.new)
       @address_search_results = address_finder.find(@address_search)
 
+      @back = Back.new(controller_name: 'describe_repair')
       return render 'address_searches/create'
     end
 

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -4,6 +4,7 @@ class ContactDetailsController < ApplicationController
     @selected_answers = selected_answer_store.selected_answers['address']
 
     @form = ContactDetailsForm.new
+    @back = Back.new(controller_name: 'address_searches')
   end
 
   def submit

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -11,6 +11,8 @@ class ContactDetailsController < ApplicationController
     selected_answer_store = SelectedAnswerStore.new(session)
     @selected_answers = selected_answer_store.selected_answers['address']
 
+    @back = Back.new(controller_name: 'address_searches')
+
     @form = ContactDetailsForm.new(contact_details_form_params)
     return render :index unless @form.valid?
 

--- a/app/controllers/describe_repair_controller.rb
+++ b/app/controllers/describe_repair_controller.rb
@@ -1,5 +1,7 @@
 class DescribeRepairController < ApplicationController
-  def index; end
+  def index
+    @back = Back.new(controller_name: 'questions/start')
+  end
 
   def submit
     redirect_to address_search_path

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 class PagesController < ApplicationController
   def address_isnt_here; end
 
-  def emergency_contact; end
+  def emergency_contact
+    @back = Back.new(controller_name: 'questions/start')
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 class PagesController < ApplicationController
-  def address_isnt_here; end
+  def address_isnt_here
+    @back = Back.new(controller_name: 'address_searches')
+  end
 
   def emergency_contact
     @back = Back.new(controller_name: 'questions/start')

--- a/app/presenters/back.rb
+++ b/app/presenters/back.rb
@@ -12,11 +12,7 @@ class Back
   private
 
   def text
-    "#{prefix} #{page_description}"
-  end
-
-  def prefix
-    I18n.t 'back_links.prefix'
+    I18n.t 'back_links.prefix', page_description: page_description
   end
 
   def page_description

--- a/app/presenters/back.rb
+++ b/app/presenters/back.rb
@@ -1,0 +1,25 @@
+class Back
+  def initialize(controller_name:, routes: Rails.application.routes)
+    @controller_name = controller_name
+    @helpers = ActionController::Base.helpers
+    @routes = routes
+  end
+
+  def link
+    @helpers.link_to text, @routes.path_for(controller: @controller_name)
+  end
+
+  private
+
+  def text
+    "#{prefix} #{page_description}"
+  end
+
+  def prefix
+    I18n.t 'back_links.prefix'
+  end
+
+  def page_description
+    I18n.t @controller_name, scope: :back_links
+  end
+end

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -35,3 +35,4 @@
     - else
       = t('address_search.not_found')
 
+%p= @back.link

--- a/app/views/address_searches/index.html.haml
+++ b/app/views/address_searches/index.html.haml
@@ -8,4 +8,4 @@
       = f.input :postcode
       = f.button :submit
 
-%p= link_to 'Back to problem details', describe_repair_path
+%p= @back.link

--- a/app/views/address_searches/index.html.haml
+++ b/app/views/address_searches/index.html.haml
@@ -8,3 +8,4 @@
       = f.input :postcode
       = f.button :submit
 
+%p= link_to 'Back to problem details', describe_repair_path

--- a/app/views/contact_details/index.html.haml
+++ b/app/views/contact_details/index.html.haml
@@ -14,4 +14,4 @@
 %aside#progress
   = @selected_answers['short_address']
 
-%p= link_to 'Back to address search', address_search_path
+%p= @back.link

--- a/app/views/contact_details/index.html.haml
+++ b/app/views/contact_details/index.html.haml
@@ -13,3 +13,5 @@
 
 %aside#progress
   = @selected_answers['short_address']
+
+%p= link_to 'Back to address search', address_search_path

--- a/app/views/describe_repair/index.html.haml
+++ b/app/views/describe_repair/index.html.haml
@@ -13,3 +13,5 @@
     .answers
       = f.input :description, as: :text
       = f.button :submit, class: 'button'
+
+%p= link_to 'Back to start', questions_start_path

--- a/app/views/describe_repair/index.html.haml
+++ b/app/views/describe_repair/index.html.haml
@@ -14,4 +14,4 @@
       = f.input :description, as: :text
       = f.button :submit, class: 'button'
 
-%p= link_to 'Back to start', questions_start_path
+%p= @back.link

--- a/app/views/pages/address_isnt_here.html.haml
+++ b/app/views/pages/address_isnt_here.html.haml
@@ -11,3 +11,5 @@
 
 %p
   We are open Monday to Friday 8am - 7pm and Saturdays 9am - 1pm.
+
+%p= @back.link

--- a/app/views/pages/emergency_contact.html.haml
+++ b/app/views/pages/emergency_contact.html.haml
@@ -6,3 +6,5 @@
 
 %p
   Please call us on 020 8356 2300 so we can help you with your problem.
+
+%p= @back.link

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
     errors:
       blank: Please choose your address to continue
   back_links:
-    prefix: Back to
+    prefix: Back to %{page_description}
     questions/start: start
     address_searches: find my address
     describe_repair: problem description

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,11 @@ en:
   addresses:
     errors:
       blank: Please choose your address to continue
+  back_links:
+    prefix: Back to
+    questions/start: start
+    address_searches: find my address
+    describe_repair: problem description
   contact-details:
     title: Who should we contact about this repair?
   errors:

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.feature 'Resident can navigate back' do
+  scenario 'taking a full happy path through the forms' do
+    property = {
+      'property_reference' => 'abc123',
+      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('properties/abc123').and_return(property)
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Describe problem:
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E8 5TQ'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
+    click_on 'Continue'
+
+    # Contact details - last page before confirmation:
+    click_on 'Back to address search'
+    expect(page).to have_content 'What is your address?'
+
+    click_on 'Back to problem details'
+    expect(page).to have_content 'Is there anything else we should know about this problem?'
+
+    click_on 'Back to start'
+    expect(page).to have_content 'Is your problem one of these?'
+  end
+
+  scenario 'going back from both address pages (search and selection)'
+  scenario 'going back after validation errors'
+  scenario 'going back from the describe unknown repair page'
+  scenario 'going back TO the describe unknown repair page'
+  scenario 'going back from the Emergency exit page'
+  scenario 'going back from the My address is not here exit page'
+end

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Resident can navigate back' do
     expect(page).to have_content 'Is your problem one of these?'
   end
 
-  scenario 'when the search was invalid' do
+  scenario 'when the address search was invalid' do
     visit '/'
     click_on 'Start'
 
@@ -59,8 +59,42 @@ RSpec.feature 'Resident can navigate back' do
     expect(page).to have_content 'Is there anything else we should know about this problem?'
   end
 
+  scenario 'when the contact details search was invalid' do
+    property = {
+      'property_reference' => 'abc123',
+      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('properties/abc123').and_return(property)
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Describe problem:
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E8 5TQ'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
+    click_on 'Continue'
+
+    # Contact details - submit an empty form
+    click_on 'Continue'
+
+    click_on t('back_links.address_searches')
+    expect(page).to have_content 'What is your address?'
+  end
+
   scenario 'going back from both address pages (search and selection)'
-  scenario 'going back after validation errors'
   scenario 'going back from the describe unknown repair page'
   scenario 'going back TO the describe unknown repair page'
   scenario 'going back from the Emergency exit page'

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -106,8 +106,38 @@ RSpec.feature 'Resident can navigate back' do
     expect(page).to have_content 'Is your problem one of these?'
   end
 
+  scenario 'going back from the My address is not here exit page' do
+    property = {
+      'property_reference' => 'abc123',
+      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Describe problem:
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E8 5TQ'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button "My address isn't here"
+    click_on 'Continue'
+
+    click_on t('back_links.address_searches')
+    expect(page).to have_content 'What is your address?'
+  end
+
   scenario 'going back from both address pages (search and selection)'
   scenario 'going back from the describe unknown repair page'
   scenario 'going back TO the describe unknown repair page'
-  scenario 'going back from the My address is not here exit page'
 end

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -30,13 +30,13 @@ RSpec.feature 'Resident can navigate back' do
     click_on 'Continue'
 
     # Contact details - last page before confirmation:
-    click_on 'Back to address search'
+    click_on t('back_links.address_searches')
     expect(page).to have_content 'What is your address?'
 
-    click_on 'Back to problem details'
+    click_on t('back_links.describe_repair')
     expect(page).to have_content 'Is there anything else we should know about this problem?'
 
-    click_on 'Back to start'
+    click_on t('back_links.questions/start')
     expect(page).to have_content 'Is your problem one of these?'
   end
 
@@ -55,7 +55,7 @@ RSpec.feature 'Resident can navigate back' do
     fill_in 'Postcode', with: ''
     click_on 'Find my address'
 
-    click_on 'Back to problem details'
+    click_on t('back_links.describe_repair')
     expect(page).to have_content 'Is there anything else we should know about this problem?'
   end
 

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -40,6 +40,25 @@ RSpec.feature 'Resident can navigate back' do
     expect(page).to have_content 'Is your problem one of these?'
   end
 
+  scenario 'when the search was invalid' do
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Describe problem:
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: ''
+    click_on 'Find my address'
+
+    click_on 'Back to problem details'
+    expect(page).to have_content 'Is there anything else we should know about this problem?'
+  end
+
   scenario 'going back from both address pages (search and selection)'
   scenario 'going back after validation errors'
   scenario 'going back from the describe unknown repair page'

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -94,9 +94,20 @@ RSpec.feature 'Resident can navigate back' do
     expect(page).to have_content 'What is your address?'
   end
 
+  scenario 'going back from the Emergency exit page' do
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'Yes'
+    click_on 'Continue'
+
+    click_on t('back_links.questions/start')
+    expect(page).to have_content 'Is your problem one of these?'
+  end
+
   scenario 'going back from both address pages (search and selection)'
   scenario 'going back from the describe unknown repair page'
   scenario 'going back TO the describe unknown repair page'
-  scenario 'going back from the Emergency exit page'
   scenario 'going back from the My address is not here exit page'
 end

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -137,7 +137,30 @@ RSpec.feature 'Resident can navigate back' do
     expect(page).to have_content 'What is your address?'
   end
 
-  scenario 'going back from both address pages (search and selection)'
+  scenario 'going back from the address selection page' do
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([])
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Describe problem:
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E8 5TQ'
+    click_on 'Find my address'
+
+    # Address selection:
+    click_on t('back_links.describe_repair')
+    expect(page).to have_content 'Is there anything else we should know about this problem?'
+  end
+
   scenario 'going back from the describe unknown repair page'
   scenario 'going back TO the describe unknown repair page'
 end

--- a/spec/presenters/back_spec.rb
+++ b/spec/presenters/back_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Back do
         .and_return('/describe-repair')
       allow(I18n)
         .to receive(:t)
-        .with('back_links.prefix')
-        .and_return('Back to')
-      allow(I18n)
-        .to receive(:t)
         .with('describe_repair', scope: :back_links)
         .and_return('problem details')
+      allow(I18n)
+        .to receive(:t)
+        .with('back_links.prefix', page_description: 'problem details')
+        .and_return('Back to problem details')
 
       expect(Back.new(controller_name: 'describe_repair', routes: fake_routes).link)
         .to eq '<a href="/describe-repair">Back to problem details</a>'

--- a/spec/presenters/back_spec.rb
+++ b/spec/presenters/back_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'app/presenters/back'
+require 'action_controller' # required for link_to
+
+RSpec.describe Back do
+  describe 'link' do
+    it 'generates a link to the previous page' do
+      fake_routes = double
+      allow(fake_routes)
+        .to receive(:path_for)
+        .with(controller: 'describe_repair')
+        .and_return('/describe-repair')
+      allow(I18n)
+        .to receive(:t)
+        .with('back_links.prefix')
+        .and_return('Back to')
+      allow(I18n)
+        .to receive(:t)
+        .with('describe_repair', scope: :back_links)
+        .and_return('problem details')
+
+      expect(Back.new(controller_name: 'describe_repair', routes: fake_routes).link)
+        .to eq '<a href="/describe-repair">Back to problem details</a>'
+    end
+  end
+end


### PR DESCRIPTION
**Merge https://github.com/LBHackney-IT/maintain-my-home/pull/17 first**

The first step of this was to glue all the pages together so that we can now click through the form (nearly) end-to-end and back again.

There's a lot of duplication in the specs - it would be nice to get rid of that somehow, but although it's currently possible to jump to arbitrary points in the form (which would be one way to shortcut this), that won't be true in future (when we check what questions you've already answered), so I don't want to cause us future pain by creating specs which will break later.

This is currently hardcoded per controller. We'll need to do something special for branching and rejoining flows, but currently there aren't any through the app (e.g. there's no way to get to the unknown repair description page) so I propose we deal with that later and implement the pending specs which I've left at that point.

In any case - there's already a LOT here :scream: