### PR TITLE
(91) Show optional fields and validation errors

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -6,6 +6,11 @@
   @extend .multiple-choice;
 }
 
+label span.optional {
+  color: $hackney-dark-grey;
+  font-size: 0.8em;
+}
+
 textarea {
   @extend .form-control;
 

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -29,3 +29,8 @@ input.string {
     background-color: $hackney-light-green;
   }
 }
+
+// Hide bullet points in error summaries
+ul.error-summary-list {
+  list-style-type: none;
+}

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -5,16 +5,12 @@ class AddressSearchesController < ApplicationController
 
   def create
     @address_search = AddressSearch.new(address_search_params[:address_search])
-
-    unless @address_search.valid?
-      render :index
-      return
-    end
+    return render :index unless @address_search.valid?
 
     address_finder = AddressFinder.new(HackneyApi.new)
     @address_search_results = address_finder.find(@address_search)
 
-    @address = Address.new
+    @form = AddressForm.new
   end
 
   private

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -2,9 +2,23 @@ class ContactDetailsController < ApplicationController
   def index
     selected_answer_store = SelectedAnswerStore.new(session)
     @selected_answers = selected_answer_store.selected_answers['address']
+
+    @form = ContactDetailsForm.new
   end
 
   def submit
+    selected_answer_store = SelectedAnswerStore.new(session)
+    @selected_answers = selected_answer_store.selected_answers['address']
+
+    @form = ContactDetailsForm.new(contact_details_form_params)
+    return render :index unless @form.valid?
+
     redirect_to confirmation_path('abc123')
+  end
+
+  private
+
+  def contact_details_form_params
+    params.require(:contact_details_form).permit!
   end
 end

--- a/app/controllers/describe_unknown_repair_controller.rb
+++ b/app/controllers/describe_unknown_repair_controller.rb
@@ -1,7 +1,18 @@
 class DescribeUnknownRepairController < ApplicationController
-  def index; end
+  def index
+    @form = DescribeUnknownRepairForm.new
+  end
 
   def submit
-    redirect_to new_address_search_path
+    @form = DescribeUnknownRepairForm.new(describe_unknown_repair_form_params)
+    return render :index unless @form.valid?
+
+    redirect_to address_search_path
+  end
+
+  private
+
+  def describe_unknown_repair_form_params
+    params.require(:describe_unknown_repair_form).permit!
   end
 end

--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -7,11 +7,7 @@ module Questions
     def submit
       @form = StartForm.new(start_form_params)
 
-      unless @form.valid?
-        flash.now[:alert] = @form.errors.full_messages
-        return render :index
-      end
-
+      return render :index unless @form.valid?
       return redirect_to emergency_contact_path if @form.priority_repair?
 
       redirect_to describe_repair_path

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,0 @@
-class Address
-  include ActiveModel::Model
-
-  attr_accessor :property_reference, :short_address
-end

--- a/app/models/address_form.rb
+++ b/app/models/address_form.rb
@@ -1,0 +1,11 @@
+class AddressForm
+  include ActiveModel::Model
+
+  attr_accessor :property_reference, :postcode
+
+  validates :property_reference, presence: true
+
+  def address_isnt_here?
+    property_reference == 'address_isnt_here'
+  end
+end

--- a/app/models/contact_details_form.rb
+++ b/app/models/contact_details_form.rb
@@ -1,0 +1,13 @@
+class ContactDetailsForm
+  include ActiveModel::Model
+
+  attr_reader :full_name, :telephone_number, :callback_time
+
+  validates :full_name, :telephone_number, :callback_time, presence: true
+
+  def initialize(hash = {})
+    @full_name = hash[:full_name]
+    @telephone_number = hash[:telephone_number]
+    @callback_time = hash[:callback_time]
+  end
+end

--- a/app/models/describe_unknown_repair_form.rb
+++ b/app/models/describe_unknown_repair_form.rb
@@ -1,0 +1,11 @@
+class DescribeUnknownRepairForm
+  include ActiveModel::Model
+
+  attr_reader :description
+
+  validates :description, presence: true
+
+  def initialize(hash = {})
+    @description = hash[:description]
+  end
+end

--- a/app/models/start_form.rb
+++ b/app/models/start_form.rb
@@ -1,23 +1,15 @@
 class StartForm
   include ActiveModel::Model
 
-  attr_reader :priority_repair
+  attr_reader :answer
 
-  validate :mandatory_fields_present
+  validates :answer, presence: true
 
   def initialize(hash = {})
-    @priority_repair = hash[:priority_repair]
+    @answer = hash[:answer]
   end
 
   def priority_repair?
-    priority_repair == 'yes'
-  end
-
-  private
-
-  def mandatory_fields_present
-    return if priority_repair.present?
-
-    errors.add(:base, I18n.t('errors.no_selection'))
+    answer == 'yes'
   end
 end

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -21,7 +21,7 @@
             collection: @address_search_results,
             label_method: :short_address,
             value_method: :property_reference,
-            label: false
+            required: true
 
           = f.input :property_reference,
             as: :radio_buttons,

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -14,7 +14,8 @@
 - if @address_search_results
   #address-search-results
     - if @address_search_results.any?
-      = simple_form_for @address, url: address_path do |f|
+      = simple_form_for @form, url: address_path do |f|
+        = f.hidden_field :postcode, value: @address_search.postcode
         %fieldset
           = f.input :property_reference,
             as: :radio_buttons,
@@ -27,7 +28,8 @@
             as: :radio_buttons,
             collection: [:address_isnt_here],
             label: false,
-            include_hidden: false
+            include_hidden: false,
+            error: false
 
           = f.button :submit, class: 'button'
     - else

--- a/app/views/address_searches/index.html.haml
+++ b/app/views/address_searches/index.html.haml
@@ -1,11 +1,10 @@
-%h1
-  What is your address?
-
-- if @address_search.errors
-  = @address_search.errors.full_messages.join(', ')
-
 = simple_form_for @address_search, url: address_search_path do |f|
   %fieldset
-    = f.input :postcode
-    = f.button :submit, class: 'button'
+    %legend.question
+      %h1
+        What is your address?
+
+    .answers
+      = f.input :postcode
+      = f.button :submit
 

--- a/app/views/contact_details/index.html.haml
+++ b/app/views/contact_details/index.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for :dummy_form, url: request.fullpath do |f|
+= simple_form_for @form, url: request.fullpath do |f|
   %fieldset
     %legend.question
       %h1= t('contact-details.title')
@@ -8,8 +8,8 @@
     .answers
       = f.input :full_name
       = f.input :telephone_number
-      = f.input :callback_time, collection: [:morning, :afternoon], as: :check_boxes
-      = f.button :submit, class: 'button'
+      = f.input :callback_time, collection: [:morning, :afternoon], as: :check_boxes, include_hidden: false
+      = f.button :submit
 
 %aside#progress
   = @selected_answers['short_address']

--- a/app/views/describe_repair/index.html.haml
+++ b/app/views/describe_repair/index.html.haml
@@ -11,5 +11,5 @@
         %li how does it impact your household?
 
     .answers
-      = f.input :description, as: :text, label: false
+      = f.input :description, as: :text
       = f.button :submit, class: 'button'

--- a/app/views/describe_unknown_repair/index.html.haml
+++ b/app/views/describe_unknown_repair/index.html.haml
@@ -1,4 +1,4 @@
-= simple_form_for :dummy_form, url: request.fullpath do |f|
+= simple_form_for @form, url: request.fullpath do |f|
   %fieldset
     %legend.question
       %h1 Please describe what needs to be fixed
@@ -11,5 +11,5 @@
         %li how does it impact your household?
 
     .answers
-      = f.input :description, as: :text, label: false
-      = f.button :submit, class: 'button'
+      = f.input :description, as: :text
+      = f.button :submit

--- a/app/views/questions/start/index.html.haml
+++ b/app/views/questions/start/index.html.haml
@@ -14,5 +14,5 @@
         %li I cannot access my property
 
     .answers
-      = f.input :priority_repair, collection: [:yes, :no], as: :radio_buttons, label: ''
+      = f.input :priority_repair, collection: [:yes, :no], as: :radio_buttons, label: false
       = f.button :submit, class: 'button'

--- a/app/views/questions/start/index.html.haml
+++ b/app/views/questions/start/index.html.haml
@@ -14,5 +14,5 @@
         %li I cannot access my property
 
     .answers
-      = f.input :priority_repair, collection: [:yes, :no], as: :radio_buttons, label: false
+      = f.input :answer, collection: [:yes, :no], as: :radio_buttons, label: false
       = f.button :submit, class: 'button'

--- a/app/views/questions/start/submit.html.haml
+++ b/app/views/questions/start/submit.html.haml
@@ -1,3 +1,0 @@
-.question
-  %h1
-    What do you need to be fixed?

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,3 +1,8 @@
+require Rails.root.join('lib', 'simple_form', 'optional_labels')
+
+SimpleForm::Components::Labels.prepend SimpleForm::Components::OptionalLabels
+SimpleForm::Components::Labels::ClassMethods.include SimpleForm::Components::OptionalLabels::ClassMethods
+
 SimpleForm.setup do |config|
   config.wrappers :default, tag: 'div',
                             class: 'form-group', error_class: 'has-error' do |b|
@@ -36,7 +41,7 @@ SimpleForm.setup do |config|
   config.error_notification_class = 'error_notification'
 
   # Whether attributes are required by default (or not). Default is true.
-  # config.required_by_default = true
+  config.required_by_default = false
 
   # Tell browsers whether to use the native HTML5 validations (novalidate form option).
   # These validations are enabled in SimpleForm's internal config but disabled by default
@@ -47,4 +52,7 @@ SimpleForm.setup do |config|
 
   # Define the default class of the input wrapper of the boolean input.
   config.boolean_label_class = 'checkbox'
+
+  # Append 'optional' label instead of prepending
+  config.label_text = ->(label, optional, _explicit_label) { "#{label}#{optional}" }
 end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -5,15 +5,15 @@ SimpleForm::Components::Labels::ClassMethods.include SimpleForm::Components::Opt
 
 SimpleForm.setup do |config|
   config.wrappers :default, tag: 'div',
-                            class: 'form-group', error_class: 'has-error' do |b|
+                            class: 'form-group', error_class: 'form-group-error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :label, class: 'form-label'
+    b.use :full_error, wrap_with: { tag: 'span', class: 'error-message' }
 
     b.wrapper tag: 'div' do |ba|
       ba.use :input
-      ba.use :error, wrap_with: { tag: 'span', class: 'form-inline' }
-      ba.use :hint,  wrap_with: { tag: 'p', class: 'form-help' }
+      ba.use :hint, wrap_with: { tag: 'p', class: 'form-help' }
     end
   end
 
@@ -27,7 +27,7 @@ SimpleForm.setup do |config|
   config.boolean_style = :inline
 
   # Default class for buttons
-  config.button_class = 'btn'
+  config.button_class = 'button'
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,18 @@
 en:
+  activemodel:
+    attributes:
+      contact_details_form:
+        callback_time: Best time to call you
+      describe_unknown_repair_form:
+        description: Problem description
+      dummy_form:
+        description: Problem description
+    errors:
+      models:
+        contact_details_form:
+          attributes:
+            callback_time:
+              blank: is required
   address_search:
     change: Change
     not_found: No addresses found

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
           morning: "morning (8am - 12pm)"
           afternoon: "afternoon (12pm - 5pm)"
       start_form:
-        priority_repair:
+        answer:
           'yes': 'Yes'
           'no': 'No'
   title: Maintain my home

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,13 +20,13 @@ en:
       address:
         new:
           property_reference: Select your address
-      dummy_form:
+      contact_details_form:
         callback_time: What time is best to call you?
     options:
       address:
         property_reference:
           address_isnt_here: "My address isn't here"
-      dummy_form:
+      contact_details_form:
         callback_time:
           morning: "morning (8am - 12pm)"
           afternoon: "afternoon (12pm - 5pm)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   activemodel:
     attributes:
+      address_form:
+        property_reference: Address
       contact_details_form:
         callback_time: Best time to call you
       describe_unknown_repair_form:
@@ -37,7 +39,7 @@ en:
       contact_details_form:
         callback_time: What time is best to call you?
     options:
-      address:
+      address_form:
         property_reference:
           address_isnt_here: "My address isn't here"
       contact_details_form:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -3,8 +3,9 @@ en:
     "yes": 'Yes'
     "no": 'No'
     required:
-      text: 'required'
-      mark: '*'
+      html: ''
+    optional:
+      html: ' <span class="optional">(optional)</span>' # NB: space at beginning
       # You can uncomment the line below if you need to overwrite the whole required html.
       # When using html, text and mark won't be used.
       # html: '<abbr title="required">*</abbr>'

--- a/lib/simple_form/optional_labels.rb
+++ b/lib/simple_form/optional_labels.rb
@@ -1,0 +1,30 @@
+module SimpleForm
+  module Components
+    module OptionalLabels
+      module ClassMethods
+        def translate_optional_html
+          i18n_cache :translate_optional_html do
+            I18n.t(
+              :"simple_form.optional.html",
+              default: translate_optional_text
+            )
+          end
+        end
+
+        def translate_optional_text
+          I18n.t(:"simple_form.optional.text", default: 'optional')
+        end
+      end
+
+      protected
+
+      def required_label_text #:nodoc:
+        if required_field?
+          self.class.translate_required_html.dup
+        else
+          self.class.translate_optional_html.dup
+        end
+      end
+    end
+  end
+end

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -136,7 +136,9 @@ RSpec.feature 'Resident can locate a problem' do
     click_button t('helpers.submit.address_search.create')
     click_button t('helpers.submit.create')
 
-    expect(page).to have_content(t('addresses.errors.blank'))
+    within '.address_form_property_reference .error-message' do
+      expect(page).to have_content t('errors.messages.blank')
+    end
   end
 
   scenario "user's address isn't listed" do
@@ -155,7 +157,7 @@ RSpec.feature 'Resident can locate a problem' do
     click_button t('helpers.submit.address_search.create')
 
     within '#address-search-results' do
-      choose_radio_button t('simple_form.options.address.property_reference.address_isnt_here')
+      choose_radio_button t('simple_form.options.address_form.property_reference.address_isnt_here')
     end
 
     click_button t('helpers.submit.create')

--- a/spec/features/users_can_answer_repair_questions_spec.rb
+++ b/spec/features/users_can_answer_repair_questions_spec.rb
@@ -20,14 +20,15 @@ RSpec.feature 'Users can answer repair questions' do
     visit '/questions/start/'
     click_continue
 
-    within '.flash-alert' do
-      expect(page).to have_content t('errors.no_selection')
+    within '.start_form_answer' do
+      expect(page).to have_css '.error-message'
+      expect(page).to have_content t('errors.messages.blank')
     end
   end
 
   scenario "Users can choose 'Yes' and get shown the emergency contact page" do
     visit '/questions/start/'
-    choose_radio_button t('simple_form.options.start_form.priority_repair.yes')
+    choose_radio_button t('simple_form.options.start_form.answer.yes')
     click_continue
 
     expect(page).to have_content 'Please call our repair centre'
@@ -35,7 +36,7 @@ RSpec.feature 'Users can answer repair questions' do
 
   scenario "Users can choose 'No' and is shown the next question" do
     visit '/questions/start/'
-    choose_radio_button t('simple_form.options.start_form.priority_repair.no')
+    choose_radio_button t('simple_form.options.start_form.answer.no')
     click_continue
 
     within '.question' do

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.feature 'Users cannot submit incomplete forms' do
+  scenario 'they are shown the form again, with errors highlighted' do
+    matching_property = {
+      'property_reference' => 'zzz',
+      'short_address' => '8A Abersham Road',
+    }
+
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=E5 8TE').and_return([matching_property])
+    allow(fake_api).to receive(:get).with('properties/zzz').and_return(matching_property)
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/'
+
+    # Start page
+    click_on 'Start'
+
+    # Emergency repairs
+    choose_radio_button 'No'
+    click_continue
+
+    # Problem description
+    click_continue
+
+    # Choose address
+    fill_in :address_search_postcode, with: 'E5 8TE'
+    click_button t('helpers.submit.address_search.create')
+    choose_radio_button '8A Abersham Road'
+    click_button t('helpers.submit.address.create')
+
+    # Submit empty contact details form
+    click_continue
+
+    expect(page).to have_css('.form-group.form-group-error')
+
+    within '.contact_details_form_full_name' do
+      expect(page).to have_css('span.error-message')
+      expect(page).to have_css('div input[aria-invalid=true]')
+    end
+
+    within '.contact_details_form_telephone_number' do
+      expect(page).to have_css('span.error-message')
+      expect(page).to have_css('div input[aria-invalid=true]')
+    end
+
+    within '.contact_details_form_callback_time' do
+      expect(page).to have_css('span.error-message')
+      expect(page).to have_css('div input[aria-invalid=true]')
+    end
+  end
+
+  private
+
+  def click_continue
+    click_button t('helpers.submit.create')
+  end
+end

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     fill_in :address_search_postcode, with: 'E5 8TE'
     click_button t('helpers.submit.address_search.create')
     choose_radio_button '8A Abersham Road'
-    click_button t('helpers.submit.address.create')
+    click_button t('helpers.submit.create')
 
     # Submit empty contact details form
     click_continue

--- a/spec/models/contact_details_form_spec.rb
+++ b/spec/models/contact_details_form_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe ContactDetailsForm do
+  describe 'validations' do
+    it 'is invalid when full_name is blank' do
+      form = ContactDetailsForm.new
+      form.valid?
+
+      expect(form.errors.details[:full_name]).to include(error: :blank)
+    end
+
+    it 'is invalid when telephone_number is blank' do
+      form = ContactDetailsForm.new
+      form.valid?
+
+      expect(form.errors.details[:telephone_number]).to include(error: :blank)
+    end
+
+    it 'is invalid when callback_time is blank' do
+      form = ContactDetailsForm.new
+      form.valid?
+
+      expect(form.errors.details[:callback_time]).to include(error: :blank)
+    end
+
+    it 'is valid when the required parameters are provided' do
+      form = ContactDetailsForm.new(
+        full_name: 'Robin Hood',
+        telephone_number: '0115 123 4567',
+        callback_time: :afternoon
+      )
+
+      expect(form).to be_valid
+    end
+  end
+end

--- a/spec/models/describe_unknown_repair_form.rb
+++ b/spec/models/describe_unknown_repair_form.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe DescribeUnknownRepairForm do
+  describe 'validations' do
+    it '.description' do
+      form = DescribeUnknownRepairForm.new
+      form.valid?
+
+      expect(form.errors.details[:description]).to include(error: :blank)
+    end
+  end
+end


### PR DESCRIPTION
 - Forms now indicate when fields are optional rather than when they are required
 - The 'describe unknown repair' and 'contact details' forms have required fields, so now have form objects to perform validation
 - Validation prevents incomplete forms being submitted
 - Validation errors are in the GOVUK style
 -  Optional fields need to have labels

<img width="517" alt="validation-errors" src="https://user-images.githubusercontent.com/3166/31181406-23af8be6-a919-11e7-9ed5-6260587f2fc5.png">

NB: GOVUK style suggested having a series of links to the invalid fields at the top of the page. This is quite hard to do because it requires some additional ARIA attributes on the form and error fields. I've therefore omitted this for now, which feels fine since we're avoiding too many questions per page.