### PR TITLE
(96) Users can continue if no addresses found

### DIFF
--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -13,9 +13,10 @@
 
 - if @address_search_results
   #address-search-results
-    - if @address_search_results.any?
-      = simple_form_for @form, url: address_path do |f|
-        = f.hidden_field :postcode, value: @address_search.postcode
+    = simple_form_for @form, url: address_path do |f|
+      = f.hidden_field :postcode, value: @address_search.postcode
+
+      - if @address_search_results.any?
         %fieldset
           = f.input :property_reference,
             as: :radio_buttons,
@@ -31,8 +32,11 @@
             include_hidden: false,
             error: false
 
-          = f.button :submit, class: 'button'
-    - else
-      = t('address_search.not_found')
+      - else
+        = f.hidden_field :property_reference, value: :address_isnt_here
+
+        %p= t('address_search.not_found')
+
+      = f.button :submit, class: 'button'
 
 %p= @back.link

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -55,6 +55,10 @@ RSpec.feature 'Resident can locate a problem' do
     within '#address-search-results' do
       expect(page).to have_content t('address_search.not_found')
     end
+
+    click_button t('helpers.submit.create')
+
+    expect(page).to have_content 'We cannot find your address'
   end
 
   scenario 'when an invalid postcode is entered' do


### PR DESCRIPTION
This situation is essentially the same as if there were addresses found,
but none of them are where the user lives.

I initially tried making the button a link, which seemed simpler, but
that means that the redirection path (to the "we cannot find your
address" page) is duplicated in two places: the controller and the view.

Submitting a form with a hidden field feels a bit clunkier, but on the
plus side, both scenarios (no addresses at all, user's address not
shown) are handled by the same code.

Ensure that Postcode is sent in both scenarios. It's only actually used
in one specific case, but it feels more predictable if the view always
returns the same data.