### PR TITLE
(127) Repairs cannot be submitted to the API without a description

### DIFF
--- a/app/services/create_repair.rb
+++ b/app/services/create_repair.rb
@@ -25,7 +25,10 @@ class CreateRepair
     end
 
     def problem
-      @answers.fetch('describe_repair').fetch('description')
+      problem = @answers.fetch('describe_repair').fetch('description')
+
+      return 'n/a' if problem.blank?
+      problem
     end
 
     def property_reference

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -54,4 +54,28 @@ RSpec.describe CreateRepair do
         .to eq '03153917'
     end
   end
+
+  it 'posts a default description, if none was provided' do
+    fake_api = instance_double('HackneyApi')
+    expect(fake_api).to receive(:create_repair)
+      .with(
+        priority: 'N',
+        problem: 'n/a',
+        propertyRef: '00034713'
+      )
+
+    fake_answers = {
+      'address' => {
+        'property_reference' => '00034713',
+        'short_address' => 'Ross Court 25',
+        'postcode' => 'E5 8TE',
+      },
+      'describe_repair' => {
+        'description' => '',
+      },
+    }
+
+    service = CreateRepair.new(api: fake_api)
+    service.call(answers: fake_answers)
+  end
 end


### PR DESCRIPTION
The API requires the `problem` attribute to be set when creating a repair, so set it to `n/a` if the user didn't complete the optional 'describe repair' form.