### PR TITLE
(168) Updated questions & workflows

### DIFF
--- a/db/questions.yml
+++ b/db/questions.yml
@@ -20,9 +20,9 @@ describe_communal_problem:
     - text: The main entrance door is damaged or not closing
     - text: The intercom is not working for my property
     - text: The lift is faulty
-    - text: There are pests or rodents
-    - text: There is a blocked drain or gully
     - text: The rubbish chute is blocked or damaged
+    - text: There is a blocked drain or gully
+    - text: There are pests or rodents
     - text: Something else
 
 faulty_lamp_post:
@@ -59,30 +59,25 @@ which_room:
 kitchen_problem:
   question: What is the problem in your kitchen?
   answers:
-    - text: Cupboards
+    - text: Cupboards or Worktop
 
-    - text: Sink
-      next: is_sink_blocked
-
-    - text: Damp or mould
-      next: describe_kitchen_damp
-
-    - text: Taps
-      next: is_kitchen_tap_stuck_open
+    - text: Damp or Mould
+      next: describe_damp
 
     - text: Electrical
       next: kitchen_electrical_problem
 
-    - text: Other
+    - text: Heating
+      next: heating_problem
+
+    - text: Sink
+      next: sink_problem
+
+    - text: Windows
+      next: window_problem
+
+    - text: Something else
       next: kitchen_other_problem
-
-is_kitchen_tap_stuck_open:
-  question: Is the tap stuck open?
-  answers:
-    - text: 'Yes'
-      page: emergency_contact
-
-    - text: 'No'
 
 kitchen_electrical_problem:
   question: Is your problem one of these?
@@ -90,71 +85,79 @@ kitchen_electrical_problem:
     - text: Extractor fan
       next: is_fan_leaking_water
 
-    - text: Lights
-      next: bathroom_lights_problem
-      todo: SHOULD GO SOMEWHERE ELSE?
+    - text: Light fitting
+      next: water_leaking_into_light
 
-    - text: Smoke detector
+    - text: Light switch
+      page: electrical_hazard_warning
+
+    - text: Smoke detector is beeping
+      page: emergency_contact
 
     - text: Sockets
       page: electrical_hazard_warning
 
-other_electrical_problem:
+    - text: Something else
+      next: kitchen_other_problem
+
+heating_problem:
   question: Is your problem one of these?
   answers:
-    - text: Light fitting
-      next: water_leaking_into_light
+    - text: The boiler or pipes are making a loud noise
 
-    - text: Light switches
-      page: electrical_hazard_warning
+    - text: Electric heater is not working
 
-    - text: Carbon monoxide detector
+    - text: I have no hot water
 
-    - text: Smoke detector
+    - text: Radiator is not working
 
-    - text: Broken power socket
-      page: electrical_hazard_warning
+    - text: Radiator is coming loose
+
+    - text: Radiator is leaking - containable
+
+    - text: Something else
+      next: describe_heating_problem
+
+sink_problem:
+  question: Is your problem one of these?
+  answers:
+    - text: Sink is blocked
+
+    - text: Sink is leaking - containable
+
+    - text: Tap won't turn off - water running
+      page: emergency_contact
+
+    - text: Tap is dripping
+
+    - text: Tap is broken
+
+    - text: Something else
+      next: describe_sink_problem
 
 bathroom_problem:
   question: What is the problem in your bathroom?
   answers:
+    - text: Basin
+      next: basin_problem
+
+    - text: Bath
+      next: bath_problem
+
+    - text: Damp or mould
+      next: describe_damp
+
+    - text: Electrical
+      next: bathroom_electrical_problem
+
+    - text: Heating
+      next: heating_problem
+
     - text: Toilet
       next: toilet_problem
 
-    - text: Taps
-      next: is_bathroom_tap_stuck_open
-
-    - text: Bath
-      next: is_bath_leaking
-
-    - text: Damp or mould
-      next: describe_bathroom_damp
-
-    - text: Basin
-      next: is_basin_leaking_or_cracked
-
-    - text: Extractor fan
-      next: is_fan_leaking_water
-
-    - text: Lights
-      next: bathroom_lights_problem
-
     - text: Something else
       next: bathroom_other_problem
-
-is_basin_leaking_or_cracked:
-  question: Is the basin leaking or cracked?
-  answers:
-    - text: 'Yes'
-
-    - text: 'No'
-      next: is_basin_blocked
-
-is_basin_blocked:
-  question: Is the basin blocked?
-  answers:
-    - text: 'Yes'
-    - text: 'No'
 
 is_fan_leaking_water:
   question: Is there water leaking into or from the fan?
@@ -164,56 +167,72 @@ is_fan_leaking_water:
 
     - text: 'No'
 
-is_bathroom_tap_stuck_open:
-  question: Is the tap stuck open?
+basin_problem:
+  question: Is your problem one of these?
   answers:
-    - text: 'Yes'
+    - text: Basin / Sink is blocked
+
+    - text: Basin / Sink is leaking - containable
+
+    - text: Tap won't turn off - water running
       page: emergency_contact
 
-    - text: 'No'
+    - text: Tap is dripping
 
-is_bath_leaking:
-  question: Is your bath leaking?
+    - text: Tap is broken
+
+    - text: Something else
+      next: describe_sink_problem
+
+bath_problem:
+  question: Is your problem one of these?
   answers:
-    - text: 'Yes'
+    - text: Bath is blocked
+
+    - text: Bath is leaking - containable
+
+    - text: Tap won't turn off - water running
       page: emergency_contact
 
-    - text: 'No'
-      next: is_bath_blocked_or_cracked
+    - text: Tap is dripping
 
-is_bath_blocked_or_cracked:
-  question: Is your bath blocked or cracked?
-  answers:
-    - text: 'Yes'
-    - text: 'No'
+    - text: Tap is broken
 
-bathroom_lights_problem:
-  question: Is the problem with the...
+    - text: Something else
+      next: describe_bath_problem
+
+bathroom_electrical_problem:
+  question: Is your problem one of these?
   answers:
+    - text: Extractor fan
+      next: is_fan_leaking_water
+
     - text: Light fitting
       next: water_leaking_into_light
 
     - text: Light switch
       page: electrical_hazard_warning
 
-bathroom_other_problem:
-  question: Are you electrics safe?
-  answers:
-    - text: 'Yes'
-
-    - text: 'No'
-      page: emergency_contact
+    - text: Something else
+      next: bathroom_other_problem
 
 other_problem:
   question: What is the problem?
   answers:
+
+   - text: Damp or mould
+     next: describe_damp
+
    - text: Electrical
      next: other_electrical_problem
 
-   - text: Heating
+   - text: External doors
+     next: external_doors_problem
 
-   - text: Damp or mould
-     todo: DESCRIBE MOULD
+   - text: Heating
+     next: heating_problem
+
+   - text: internal doors
 
    - text: Gas
      page: emergency_contact
@@ -221,58 +240,56 @@ other_problem:
    - text: Windows
      next: window_problem
 
-   - text: External doors
-     next: external_doors_problem
-
-   - text: Internal doors
-
    - text: Something else
      next: describe_unknown_repair
-     todo: UNSAFE ELECTRICS?
+
+
+other_electrical_problem:
+  question: Is your problem one of these?
+  answers:
+    - text: Extractor fan
+      next: is_fan_leaking_water
+
+    - text: Light fitting
+      next: water_leaking_into_light
+
+    - text: Light switch
+      page: electrical_hazard_warning
+
+    - text: Smoke detector is beeping
+      page: emergency_contact
+
+    - text: Carbon Monoxide detector is beeping
+      page: emergency_contact
+
+    - text: Sockets
+      page: electrical_hazard_warning
+
+    - text: Something else
+      next: other_electrical_problem
 
 describe_unknown_repair:
   question: Please describe the problem you need repairing...
 
 window_problem:
-  question: Are you able to close the window securely?
+  question: Is your problem one of these?
   answers:
-    - text: 'Yes'
-      next: window_glass_damaged
+    - text: Window is not shutting / locking (above ground floor)
 
-    - text: 'No'
-      page: emergency_contact
+    - text: Minor damage to glazing
 
-window_glass_damaged:
-  question: Is there damage to the glass?
-  answers:
-    - text: 'Yes'
-      page: emergency_contact
+    - text: Something else
+      next: describe_window_problem
 
-    - text: 'No'
-      next: window_material
-
-window_material:
-  question: Is your door made out of...
-  answers:
-    - text: Wood
-    - text: PVC
 
 external_doors_problem:
   question: Are you able to secure access to your property?
   answers:
     - text: 'Yes'
-      next: fire_door
-
-    - text: 'No'
-      page: emergency_contact
-
-fire_door:
-  question: Is it a fire door?
-  answers:
-    - text: 'Yes'
-      page: emergency_contact
-    - text: 'No'
       next: describe_external_door_problem
+
+    - text: 'No'
+      page: emergency_contact
 
 describe_external_door_problem:
   question: Please describe the problem with the external door...
@@ -284,19 +301,11 @@ water_leaking_into_light:
       page: emergency_contact
 
     - text: 'No'
-      next: who_fitted_light
-
-who_fitted_light:
-  question: Did you fit the light yourself?
-  answers:
-    - text: 'Yes'
-      page: repair_your_responsibility
-
-    - text: 'No'
       next: light_check_trip_switches
 
+
 light_check_trip_switches:
-  question: Have you checked the trip switches?
+  question: Have you checked the trip switches in the fuse box?
   answers:
     - text: 'Yes'
       page: replace_lightbulb
@@ -305,63 +314,45 @@ light_check_trip_switches:
       page: check_fusebox
 
 toilet_problem:
-  question: Is your toilet...?
+  question: Is your problem one of these?
   answers:
-    - text: Blocked
-      next: blocked_only_toilet
+    - text: Toilet is blocked
+      page: blocked_only_toilet
 
-    - text: Not flushing
-
-    - text: Cracked
-
-    - text: Leaking
-      next: toilet_flood_danger
-
-toilet_flood_danger:
-  question: Is there danger of flooding?
-  answers:
-    - text: 'Yes'
-      page: emergency_contact
-
-    - text: 'No'
-
-blocked_only_toilet:
-  question: Is this your only toilet?
-  answers:
-    - text: 'Yes'
-      page: emergency_contact
-    - text: 'No'
+    - text: Toilet is not flushing
       page: toilet_unblock_info
 
-is_sink_blocked:
-  question: Is your sink blocked?
-  answers:
-    - text: 'Yes'
-      page: kitchen_sink_unblock_info
+    - text: Toilet is cracked
 
-    - text: 'No'
-      next: is_sink_leaking
+    - text: Toilet is leaking - containable
 
-is_sink_leaking:
-  question: Is your sink leaking?
-  answers:
-    - text: 'Yes'
-      page: emergency_contact
+    - text: Something else
+      next: describe_toilet_problem
 
-    - text: 'No'
-      next: describe_sink_problem
 
 describe_sink_problem:
-  question: Please describe the problem with your sink
+  question: Please describe the problem with your sink / basin
 
-describe_kitchen_damp:
-  question: Please give details of the damp in your kitchen
+describe_bath_problem:
+  question: Please describe the problem with your bath
 
-describe_bathroom_damp:
-  question: Please give details of the damp in your bathroom
+describe_toilet_problem:
+  question: Please describe the problem with your toilet
+
+describe_heating_problem:
+  question: Please describe the problem with your heating
+
+describe_window_problem:
+  question: Please describe the problem with your kitchen window
+
+describe_damp:
+  question: Please give details of the damp or mould
 
 kitchen_other_problem:
   question: What is the problem in your kitchen?
 
 bathroom_other_problem:
   question: What is the problem in your bathroom?
+
+other_elecrical_problem:
+  question: What is the problem with your electrics?


### PR DESCRIPTION
Significant changes to existing repairs workflows

To consider:
- Created multiple instances of 'describe_item_problem pages 
Do we need separate instance of page when a simple text change is required?

- Created 3 individual instances of electrical_problems for each room type
Is there a way to use one global electrical_problems branch and then +- repair types per room?

- Gas & Carbon Monoxide need to divert to national grid contact message (new page)

- Require additional pages for light bulb check question & resulting help messaging