### PR TITLE
(161) Residents can book a repair appointment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,3 +40,4 @@ Metrics/LineLength:
 Metrics/BlockLength:
     Exclude:
       - 'spec/**/*'
+      - 'config/routes.rb'

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,0 +1,11 @@
+class AppointmentsController < ApplicationController
+  def show
+    @appointments = Appointments.new(['Thursday Afternoon (11th October)'])
+  end
+
+  def submit
+    redirect_to confirmation_path(params[:work_order_reference])
+  end
+
+  Appointments = Struct.new(:slots_for_collection)
+end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -12,11 +12,7 @@ class AppointmentsController < ApplicationController
       return render :show
     end
 
-    HackneyApi.new.book_appointment(
-      work_order_reference: work_order_reference,
-      begin_date: @form.begin_date,
-      end_date: @form.end_date
-    )
+    book_appointment_save_into_answer_store
 
     redirect_to confirmation_path(params[:repair_request_reference])
   end
@@ -41,5 +37,17 @@ class AppointmentsController < ApplicationController
     )
 
     appointments.map { |a| AppointmentPresenter.new(a) }
+  end
+
+  def book_appointment_save_into_answer_store
+    appointment = HackneyApi.new.book_appointment(
+      work_order_reference: work_order_reference,
+      begin_date: @form.begin_date,
+      end_date: @form.end_date
+    )
+
+    selected_answer_store.store_selected_answers(
+      'appointment', appointment
+    )
   end
 end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -12,7 +12,11 @@ class AppointmentsController < ApplicationController
       return render :show
     end
 
-    # TODO: Book appointment
+    HackneyApi.new.book_appointment(
+      work_order_reference: work_order_reference,
+      begin_date: @form.begin_date,
+      end_date: @form.end_date
+    )
 
     redirect_to confirmation_path(params[:repair_request_reference])
   end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,11 +1,41 @@
 class AppointmentsController < ApplicationController
   def show
-    @appointments = Appointments.new(['Thursday Afternoon (11th October)'])
+    @form = AppointmentForm.new
+    @appointments = available_appointments
   end
 
   def submit
-    redirect_to confirmation_path(params[:work_order_reference])
+    @form = AppointmentForm.new(appointment_form_params)
+
+    if @form.invalid?
+      @appointments = available_appointments
+      return render :show
+    end
+
+    # TODO: Book appointment
+
+    redirect_to confirmation_path(params[:repair_request_reference])
   end
 
-  Appointments = Struct.new(:slots_for_collection)
+  private
+
+  def appointment_form_params
+    params.require(:appointment_form).permit(:appointment_id)
+  end
+
+  def work_order_reference
+    Repair.new(
+      HackneyApi.new.get_repair(
+        repair_request_reference: params[:repair_request_reference]
+      )
+    ).work_order_reference
+  end
+
+  def available_appointments
+    appointments = HackneyApi.new.list_available_appointments(
+      work_order_reference: work_order_reference
+    )
+
+    appointments.map { |a| AppointmentPresenter.new(a) }
+  end
 end

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -13,7 +13,7 @@ class ContactDetailsController < ApplicationController
       result =
         CreateRepair.new.call(answers: selected_answer_store.selected_answers)
 
-      redirect_to confirmation_path(result.request_reference)
+      redirect_to appointments_path(result.request_reference)
     else
       render :index
     end

--- a/app/models/appointment_form.rb
+++ b/app/models/appointment_form.rb
@@ -1,0 +1,11 @@
+class AppointmentForm
+  include ActiveModel::Model
+
+  attr_reader :appointment_id
+
+  validates :appointment_id, presence: true
+
+  def initialize(hash = {})
+    @appointment_id = hash[:appointment_id]
+  end
+end

--- a/app/models/appointment_form.rb
+++ b/app/models/appointment_form.rb
@@ -8,4 +8,18 @@ class AppointmentForm
   def initialize(hash = {})
     @appointment_id = hash[:appointment_id]
   end
+
+  def begin_date
+    split_date.first
+  end
+
+  def end_date
+    split_date.last
+  end
+
+  private
+
+  def split_date
+    @split_date ||= @appointment_id.to_s.split('|')
+  end
 end

--- a/app/models/appointment_form.rb
+++ b/app/models/appointment_form.rb
@@ -1,4 +1,6 @@
 class AppointmentForm
+  class InvalidAppointment < StandardError; end
+
   include ActiveModel::Model
 
   attr_reader :appointment_id
@@ -7,6 +9,8 @@ class AppointmentForm
 
   def initialize(hash = {})
     @appointment_id = hash[:appointment_id]
+
+    validate_appointment_dates!
   end
 
   def begin_date
@@ -21,5 +25,19 @@ class AppointmentForm
 
   def split_date
     @split_date ||= @appointment_id.to_s.split('|')
+  end
+
+  def validate_appointment_dates!
+    return unless @appointment_id
+
+    raise InvalidAppointment unless split_date.size == 2
+
+    split_date.each do |date|
+      begin
+        Time.zone.parse(date)
+      rescue ArgumentError
+        raise InvalidAppointment
+      end
+    end
   end
 end

--- a/app/presenters/appointment.rb
+++ b/app/presenters/appointment.rb
@@ -1,5 +1,0 @@
-class Appointment
-  def to_partial_path
-    '/confirmations/appointment'
-  end
-end

--- a/app/presenters/appointment_presenter.rb
+++ b/app/presenters/appointment_presenter.rb
@@ -51,10 +51,20 @@ class AppointmentPresenter
   end
 
   def begin_time
-    I18n.l(begin_date, format: '%l:%M%P').strip
+    friendly_time(begin_date)
   end
 
   def end_time
-    I18n.l(end_date, format: '%l:%M%P').strip
+    friendly_time(end_date)
+  end
+
+  def friendly_time(time)
+    format = if time.strftime('%M').to_i.zero?
+               '%l%P'
+             else
+               '%l:%M%P'
+             end
+
+    I18n.l(time, format: format).strip
   end
 end

--- a/app/presenters/appointment_presenter.rb
+++ b/app/presenters/appointment_presenter.rb
@@ -16,6 +16,14 @@ class AppointmentPresenter
     "#{day_of_week} #{begin_time}-#{end_time} (#{day} #{month})"
   end
 
+  def date
+    "#{day_of_week} #{day} #{month}"
+  end
+
+  def time
+    [begin_time, end_time].to_sentence
+  end
+
   def to_partial_path
     '/confirmations/appointment'
   end

--- a/app/presenters/appointment_presenter.rb
+++ b/app/presenters/appointment_presenter.rb
@@ -1,0 +1,52 @@
+class AppointmentPresenter
+  include ActiveSupport::Inflector
+
+  def initialize(appointment = {})
+    @appointment = appointment
+  end
+
+  def appointment_id
+    [
+      @appointment.fetch('beginDate'),
+      @appointment.fetch('endDate'),
+    ].join('|')
+  end
+
+  def description
+    "#{day_of_week} #{begin_time}-#{end_time} (#{day} #{month})"
+  end
+
+  def to_partial_path
+    '/confirmations/appointment'
+  end
+
+  private
+
+  def begin_date
+    Time.zone.parse(@appointment.fetch('beginDate'))
+  end
+
+  def end_date
+    Time.zone.parse(@appointment.fetch('endDate'))
+  end
+
+  def day_of_week
+    I18n.l(begin_date, format: '%A')
+  end
+
+  def month
+    I18n.l(begin_date, format: '%B')
+  end
+
+  def day
+    ordinalize(begin_date.day)
+  end
+
+  def begin_time
+    I18n.l(begin_date, format: '%l:%M%P').strip
+  end
+
+  def end_time
+    I18n.l(end_date, format: '%l:%M%P').strip
+  end
+end

--- a/app/presenters/confirmation.rb
+++ b/app/presenters/confirmation.rb
@@ -38,7 +38,8 @@ class Confirmation
       time_slot = callback.fetch('callback_time')
       Callback.new(time_slot: time_slot, request_reference: @request_reference)
     else
-      AppointmentPresenter.new
+      appointment = @answers.fetch('appointment')
+      AppointmentPresenter.new(appointment)
     end
   end
 

--- a/app/presenters/confirmation.rb
+++ b/app/presenters/confirmation.rb
@@ -38,7 +38,7 @@ class Confirmation
       time_slot = callback.fetch('callback_time')
       Callback.new(time_slot: time_slot, request_reference: @request_reference)
     else
-      Appointment.new
+      AppointmentPresenter.new
     end
   end
 

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -18,4 +18,10 @@ class HackneyApi
   def get_repair(repair_request_reference:)
     @json_api.get('repairs/' + repair_request_reference)
   end
+
+  def list_available_appointments(work_order_reference:)
+    @json_api.get(
+      'work_orders/' + work_order_reference + '/appointments'
+    )
+  end
 end

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -24,4 +24,12 @@ class HackneyApi
       'work_orders/' + work_order_reference + '/appointments'
     )
   end
+
+  def book_appointment(work_order_reference:, begin_date:, end_date:)
+    @json_api.post(
+      'work_orders/' + work_order_reference + '/appointments',
+      beginDate: begin_date,
+      endDate: end_date
+    )
+  end
 end

--- a/app/views/appointments/show.html.haml
+++ b/app/views/appointments/show.html.haml
@@ -1,0 +1,3 @@
+= simple_form_for :dummy_form, url: request.fullpath do |f|
+  = f.input :answer, collection: @appointments.slots_for_collection, as: :radio_buttons, label: false
+  = f.button :submit, 'Book this appointment', class: 'button'

--- a/app/views/appointments/show.html.haml
+++ b/app/views/appointments/show.html.haml
@@ -5,5 +5,11 @@
         Please choose a date and time that suits you
 
     .answers
-      = f.input :appointment_id, collection: @appointments, label_method: :description, as: :radio_buttons, label: false
+      = f.input :appointment_id,
+        collection: @appointments,
+        value_method: :appointment_id,
+        label_method: :description,
+        as: :radio_buttons,
+        label: false
+
       = f.button :submit, class: 'button'

--- a/app/views/appointments/show.html.haml
+++ b/app/views/appointments/show.html.haml
@@ -1,3 +1,9 @@
-= simple_form_for :dummy_form, url: request.fullpath do |f|
-  = f.input :answer, collection: @appointments.slots_for_collection, as: :radio_buttons, label: false
-  = f.button :submit, 'Book this appointment', class: 'button'
+= simple_form_for @form, url: request.fullpath do |f|
+  %fieldset
+    %legend.question
+      %h1
+        Please choose a date and time that suits you
+
+    .answers
+      = f.input :appointment_id, collection: @appointments, label_method: :description, as: :radio_buttons, label: false
+      = f.button :submit, class: 'button'

--- a/app/views/confirmations/_appointment.html.haml
+++ b/app/views/confirmations/_appointment.html.haml
@@ -1,0 +1,8 @@
+%p
+  Your appointment has been booked for
+  %strong
+    = appointment.date
+  between
+  %strong
+    = succeed '.' do
+      = appointment.time

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,9 @@ Rails.application.routes.draw do
   post '/contact-details-with-callback',
        to: 'contact_details_with_callback#submit'
 
-  get '/appointments/:work_order_reference',
+  get '/appointments/:repair_request_reference',
       to: 'appointments#show',
       as: 'appointments'
-  post '/appointments/:work_order_reference',
+  post '/appointments/:repair_request_reference',
        to: 'appointments#submit'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,10 @@ Rails.application.routes.draw do
       as: 'contact_details_with_callback'
   post '/contact-details-with-callback',
        to: 'contact_details_with_callback#submit'
+
+  get '/appointments/:work_order_reference',
+      to: 'appointments#show',
+      as: 'appointments'
+  post '/appointments/:work_order_reference',
+       to: 'appointments#submit'
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -37,8 +37,16 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         ]
       )
     allow(fake_api).to receive(:post)
-      .with('work_orders/09124578/appointments', anything)
-      .and_return nil # TODO: return a realistic response
+      .with(
+        'work_orders/09124578/appointments',
+        beginDate: '2017-10-11T12:00:00Z',
+        endDate: '2017-10-11T17:00:00Z',
+      )
+      .and_return(
+        'beginDate' => '2017-10-11T12:00:00Z',
+        'endDate' => '2017-10-11T17:00:00Z',
+        'status' => 'booked',
+      )
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     fake_question_set = instance_double(QuestionSet)

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -126,14 +126,14 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     click_on 'Continue'
 
     # Appointments:
-    choose_radio_button 'Wednesday 12:00pm-5:00pm (11th October)'
+    choose_radio_button 'Wednesday 12pm-5pm (11th October)'
     click_on 'Continue'
 
     aggregate_failures do
       within '#confirmation' do
         expect(page).to have_content 'Your reference number is 09124578'
         expect(page).to have_content 'Wednesday 11th October'
-        expect(page).to have_content 'between 12:00pm and 5:00pm'
+        expect(page).to have_content 'between 12pm and 5pm'
       end
 
       within '#summary' do

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       within '#confirmation' do
         expect(page).to have_content 'Your reference number is 09124578'
         expect(page).to have_content 'Wednesday 11th October'
-        expect(page).to have_content 'between 12pm and 5pm'
+        expect(page).to have_content 'between 12:00pm and 5:00pm'
       end
 
       within '#summary' do
@@ -157,10 +157,9 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     )
 
     expect(fake_api).to have_received(:post).with(
-      'repair_appointments',
-      jobCode: '0078965',
-      startTime: '2017-10-11T12:00:00Z',
-      endTime: '2017-10-11T17:00:00Z',
+      'work_orders/09124578/appointments',
+      beginDate: '2017-10-11T12:00:00Z',
+      endDate: '2017-10-11T17:00:00Z',
     )
   end
 

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -29,16 +29,15 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'propertyRef' => '00000503',
       )
     allow(fake_api).to receive(:get)
-      .with('repair_work_orders/09124578/appointments')
+      .with('work_orders/09124578/appointments')
       .and_return(
         [
-          { 'appointmentId' => '1000', 'startDate' => '2017-10-11', 'slotTypeCode' => 'morning' },
-          { 'appointmentId' => '1001', 'startDate' => '2017-10-11', 'slotTypeCode' => 'afternoon' },
-          { 'appointmentId' => '1002', 'startDate' => '2017-10-12', 'slotTypeCode' => 'morning' },
+          { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
+          { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
         ]
       )
     allow(fake_api).to receive(:post)
-      .with('repair_work_orders/09124578/appointments', anything)
+      .with('work_orders/09124578/appointments', anything)
       .and_return nil # TODO: return a realistic response
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -119,7 +118,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     click_on 'Continue'
 
     # Appointments:
-    choose_radio_button 'Wednesday afternoon (11th October)'
+    choose_radio_button 'Wednesday 12:00pm-5:00pm (11th October)'
     click_on 'Continue'
 
     aggregate_failures do

--- a/spec/models/appointment_form_spec.rb
+++ b/spec/models/appointment_form_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentForm do
+  describe 'validations' do
+    it 'is invalid when an appointment not chosen' do
+      form = AppointmentForm.new
+      form.valid?
+
+      expect(form.errors.details[:appointment_id]).to include(error: :blank)
+    end
+  end
+end

--- a/spec/models/appointment_form_spec.rb
+++ b/spec/models/appointment_form_spec.rb
@@ -8,5 +8,35 @@ RSpec.describe AppointmentForm do
 
       expect(form.errors.details[:appointment_id]).to include(error: :blank)
     end
+
+    it 'raises an exception if appointment_id does not contain two dates' do
+      input = { appointment_id: '2017-12-25:12:34:56Z' }
+
+      expect { AppointmentForm.new(input) }
+        .to raise_error(AppointmentForm::InvalidAppointment)
+    end
+
+    it 'raises an exception if appointment_id is not formatted correctly' do
+      input = { appointment_id: 'invalid|2017-12-25:10:10:10Z' }
+
+      expect { AppointmentForm.new(input) }
+        .to raise_error(AppointmentForm::InvalidAppointment)
+    end
+  end
+
+  describe '#begin_date'  do
+    it 'is extracted from the appointment_id parameter' do
+      input = { appointment_id: '2017-11-09T10:00:00Z|2017-11-09T12:00:00Z' }
+
+      expect(AppointmentForm.new(input).begin_date).to eql '2017-11-09T10:00:00Z'
+    end
+  end
+
+  describe '#end_date' do
+    it 'is extracted from the appointment_id parameter' do
+      input = { appointment_id: '2017-11-09T10:00:00Z|2017-11-09T12:00:00Z' }
+
+      expect(AppointmentForm.new(input).end_date).to eql '2017-11-09T12:00:00Z'
+    end
   end
 end

--- a/spec/presenters/appointment_presenter_spec.rb
+++ b/spec/presenters/appointment_presenter_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentPresenter do
+  it 'is renderable' do
+    expect(AppointmentPresenter.new.to_partial_path).to eq '/confirmations/appointment'
+  end
+
+  describe '#appointment_id' do
+    it 'returns the begin and end dates concatenated together' do
+      presenter = AppointmentPresenter.new(
+        'beginDate' => '2017-12-25T12:00:00Z',
+        'endDate' => '2017-12-25T16:45:00Z',
+        'bestSlot' => true
+      )
+
+      expect(presenter.appointment_id).to eql '2017-12-25T12:00:00Z|2017-12-25T16:45:00Z'
+    end
+  end
+
+  describe '#description' do
+    it 'returns the appointment slot in a human-readable format' do
+      presenter = AppointmentPresenter.new(
+        'beginDate' => '2017-12-25T12:00:00Z',
+        'endDate' => '2017-12-25T16:45:00Z',
+        'bestSlot' => true
+      )
+
+      expect(presenter.description).to eql 'Monday 12:00pm-4:45pm (25th December)'
+    end
+  end
+end

--- a/spec/presenters/appointment_presenter_spec.rb
+++ b/spec/presenters/appointment_presenter_spec.rb
@@ -18,14 +18,24 @@ RSpec.describe AppointmentPresenter do
   end
 
   describe '#description' do
-    it 'returns the appointment slot in a human-readable format' do
+    it 'returns the appointment in a human-readable format' do
       presenter = AppointmentPresenter.new(
-        'beginDate' => '2017-12-25T12:00:00Z',
+        'beginDate' => '2017-12-25T12:15:00Z',
         'endDate' => '2017-12-25T16:45:00Z',
         'bestSlot' => true
       )
 
-      expect(presenter.description).to eql 'Monday 12:00pm-4:45pm (25th December)'
+      expect(presenter.description).to eql 'Monday 12:15pm-4:45pm (25th December)'
+    end
+
+    it 'returns times on the hour without :00' do
+      presenter = AppointmentPresenter.new(
+        'beginDate' => '2017-12-25T13:00:00Z',
+        'endDate' => '2017-12-25T16:00:00Z',
+        'bestSlot' => true
+      )
+
+      expect(presenter.description).to eql 'Monday 1pm-4pm (25th December)'
     end
   end
 
@@ -49,7 +59,7 @@ RSpec.describe AppointmentPresenter do
         'bestSlot' => true
       )
 
-      expect(presenter.time).to eql '12:00pm and 4:45pm'
+      expect(presenter.time).to eql '12pm and 4:45pm'
     end
   end
 end

--- a/spec/presenters/appointment_presenter_spec.rb
+++ b/spec/presenters/appointment_presenter_spec.rb
@@ -28,4 +28,28 @@ RSpec.describe AppointmentPresenter do
       expect(presenter.description).to eql 'Monday 12:00pm-4:45pm (25th December)'
     end
   end
+
+  describe '#date' do
+    it 'returns the appointment date in a format suitable for the confirmation page' do
+      presenter = AppointmentPresenter.new(
+        'beginDate' => '2017-12-25T12:00:00Z',
+        'endDate' => '2017-12-25T16:45:00Z',
+        'bestSlot' => true
+      )
+
+      expect(presenter.date).to eql 'Monday 25th December'
+    end
+  end
+
+  describe '#time' do
+    it 'returns the appointment times in a format suitable for the confirmation page' do
+      presenter = AppointmentPresenter.new(
+        'beginDate' => '2017-12-25T12:00:00Z',
+        'endDate' => '2017-12-25T16:45:00Z',
+        'bestSlot' => true
+      )
+
+      expect(presenter.time).to eql '12:00pm and 4:45pm'
+    end
+  end
 end

--- a/spec/presenters/appointment_spec.rb
+++ b/spec/presenters/appointment_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-require 'app/presenters/appointment'
-
-RSpec.describe Appointment do
-  it 'is renderable' do
-    expect(Appointment.new.to_partial_path).to eq '/confirmations/appointment'
-  end
-end

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'app/models/repair'
 require 'app/presenters/callback'
-require 'app/presenters/appointment'
+require 'app/presenters/appointment_presenter'
 require 'app/presenters/confirmation'
 
 RSpec.describe Confirmation do

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -101,4 +101,33 @@ describe HackneyApi do
       expect(api.list_available_appointments(work_order_reference: '00412371')).to eql result
     end
   end
+
+  describe '#book_appointment' do
+    it 'books an appointment for a work order' do
+      result = {
+        'beginDate' => '2017-11-01T14:00:00Z',
+        'endDate' => '2017-11-01T16:30:00Z',
+        'status' => 'booked',
+      }
+
+      json_api = instance_double('JsonApi')
+      allow(json_api)
+        .to receive(:post)
+        .with(
+          'work_orders/00412371/appointments',
+          beginDate: '2017-11-01T14:00:00Z',
+          endDate: '2017-11-01T16:30:00Z'
+        )
+        .and_return(result)
+
+      api = HackneyApi.new(json_api)
+      expect(
+        api.book_appointment(
+          work_order_reference: '00412371',
+          begin_date: '2017-11-01T14:00:00Z',
+          end_date: '2017-11-01T16:30:00Z'
+        )
+      ).to eql result
+    end
+  end
 end

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -78,4 +78,27 @@ describe HackneyApi do
       expect(api.get_repair(repair_request_reference: '00045678')).to eql result
     end
   end
+
+  describe '#list_available_appointments' do
+    it 'returns a list of available appointments for a work order' do
+      result = [
+        {
+          'beginDate' => '2017-11-01T08:00:00Z',
+          'endDate' => '2017-11-01T12:00:00Z',
+          'bestSlot' => true,
+        },
+        {
+          'beginDate' => '2017-11-01T12:00:00Z',
+          'endDate' => '2017-11-01T16:15:00Z',
+          'bestSlot' => false,
+        },
+      ]
+
+      json_api = instance_double('JsonApi')
+      allow(json_api).to receive(:get).with('work_orders/00412371/appointments').and_return(result)
+      api = HackneyApi.new(json_api)
+
+      expect(api.list_available_appointments(work_order_reference: '00412371')).to eql result
+    end
+  end
 end


### PR DESCRIPTION
Allow a resident to choose from a list of available appointments. 

NB: Whilst the tests pass, the API doesn't yet provide the real endpoints, so this cannot be run 'live'. Also, the stubbed endpoints are subject to change.