### PR TITLE
(183) Allow the Rails App to talk to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ The app should run successfully without these environment variables:
 
 #### Authentication
 
- - `HTTP_AUTH_USER` / `HTTP_AUTH_PASSWORD` - Set these to protect the site with
+- `HTTP_AUTH_USER` / `HTTP_AUTH_PASSWORD` - Set these to protect the site with
    [HTTP Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)
+- `PROXY_API_CERT` / `PROXY_API_KEY` - Client SSL certificate and associated
+  private key - used if connecting to the Hackney API via a proxy server
 
 
 ## TODO:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ should be set directly on the server. In development these can be managed by
 [dotenv](https://github.com/bkeepers/dotenv): create a `.env.local` file in the
 root of the application containing environment variable assignments.
 
+### Required config
+
 The following environment variables are required to run the site:
 
-- `API_ROOT` - the root of the Hackney API which is used by the site
+- `HACKNEY_API_ROOT` - the root of the Hackney API which is used by the site
 
-The following environment variables are optional:
+### Optional config
 
-### Analytics
+The app should run successfully without these environment variables:
+
+#### Analytics
 
 - `GOOGLE_ANALYTICS_ID` - The
   [tracking code](https://support.google.com/analytics/answer/1008080#trackingID)
@@ -25,7 +29,7 @@ The following environment variables are optional:
   [Hotjar Snippet Version](https://docs.hotjar.com/v1.0/docs/understanding-the-tracking-code)
   i.e. the version of the Hotjar tracking code being used
 
-### Authentication
+#### Authentication
 
  - `HTTP_AUTH_USER` / `HTTP_AUTH_PASSWORD` - Set these to protect the site with
    [HTTP Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -1,15 +1,11 @@
 class JsonApi
   class Error < StandardError; end
-  class InvalidApiRootError < StandardError; end
-  class InvalidResponseError < StandardError; end
+  class InvalidApiRootError < Error; end
+  class MissingPrivateKeyError < Error; end
+  class InvalidResponseError < Error; end
 
-  def initialize(api_root: ENV['HACKNEY_API_ROOT'])
-    raise InvalidApiRootError, 'API root was nil or empty' if api_root.blank?
-
-    @connection = Faraday.new api_root do |conn|
-      conn.adapter Faraday.default_adapter
-      conn.response :json
-    end
+  def initialize(api_config = {})
+    @connection = ConnectionBuilder.new.build(api_config)
   end
 
   def get(path)
@@ -26,5 +22,41 @@ class JsonApi
     response.body
   rescue Faraday::ParsingError => e
     raise InvalidResponseError, e.message
+  end
+
+  class ConnectionBuilder
+    def build(
+      api_root: ENV['HACKNEY_API_ROOT'],
+      api_cert: ENV['PROXY_API_CERT'],
+      api_key: ENV['PROXY_API_KEY']
+    )
+      raise InvalidApiRootError, 'API root was nil or empty' if api_root.blank?
+
+      build_connection(
+        root: api_root,
+        ssl: ssl_options(
+          cert: api_cert,
+          key: api_key,
+        )
+      )
+    end
+
+    private
+
+    def build_connection(root:, ssl:)
+      Faraday.new root, ssl: ssl do |conn|
+        conn.adapter Faraday.default_adapter
+        conn.response :json
+      end
+    end
+
+    def ssl_options(cert:, key:)
+      return {} if cert.nil?
+      raise MissingPrivateKeyError if key.nil?
+      {
+        client_cert: OpenSSL::X509::Certificate.new(cert),
+        client_key:  OpenSSL::PKey::RSA.new(key),
+      }
+    end
   end
 end

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -4,7 +4,7 @@ class JsonApi
   class InvalidResponseError < StandardError; end
 
   def initialize(api_root: ENV['HACKNEY_API_ROOT'])
-    raise InvalidApiRootError, 'api_root was nil or empty' if api_root.blank?
+    raise InvalidApiRootError, 'API root was nil or empty' if api_root.blank?
 
     @connection = Faraday.new api_root do |conn|
       conn.adapter Faraday.default_adapter

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -4,69 +4,7 @@ require 'app/queries/json_api'
 require 'active_support/core_ext/object/blank'
 
 RSpec.describe JsonApi do
-  describe '#get' do
-    context 'with a path matching properties?postcode=' do
-      it 'parses a JSON response' do
-        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
-          .to_return(
-            body: [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }].to_json,
-            headers: { content_type: 'application/json' }
-          )
-
-        result = json_api.get('properties?postcode=A1 1AA')
-
-        expect(result).to eq [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }]
-      end
-
-      it 'parses a JSON response with an unspecified content_type' do
-        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
-          .to_return(
-            body: [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }].to_json
-          )
-
-        result = json_api.get('properties?postcode=A1 1AA')
-
-        expect(result).to eq [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }]
-      end
-
-      it 'raises an exception for an invalid json response' do
-        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
-          .to_return(
-            body: '<html><body>An error occurred</body></html>'
-          )
-
-        expect { json_api.get('properties?postcode=A1 1AA') }
-          .to raise_error(JsonApi::InvalidResponseError, "765: unexpected token at '<html><body>An error occurred</body></html>'")
-      end
-
-      it 'handles an empty response body' do
-        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
-
-        result = json_api.get('properties?postcode=A1 1AA')
-
-        expect(result).to eq nil
-      end
-    end
-
-    context 'with a path matching properties/:property_reference' do
-      it 'parses a JSON response' do
-        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:get, 'http://hackney.api:8000/properties/zxc098')
-          .to_return(
-            body: { 'uprn' => 'xyz987', 'property_reference' => 'abc123', 'short_address' => '1 some road' }.to_json,
-            headers: { content_type: 'application/json' }
-          )
-
-        result = json_api.get('properties/zxc098')
-
-        expect(result).to eq('uprn' => 'xyz987', 'property_reference' => 'abc123', 'short_address' => '1 some road')
-      end
-    end
-
+  describe 'construction' do
     context 'when the api root is missing' do
       it 'raises an exception' do
         expect { JsonApi.new(api_root: nil) }
@@ -86,6 +24,53 @@ RSpec.describe JsonApi do
         expect { JsonApi.new(api_root: '  ') }
           .to raise_error(JsonApi::InvalidApiRootError)
       end
+    end
+  end
+
+  describe '#get' do
+    it 'parses a JSON response' do
+      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+      stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+        .to_return(
+          body: [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }].to_json,
+          headers: { content_type: 'application/json' }
+        )
+
+      result = json_api.get('properties?postcode=A1 1AA')
+
+      expect(result).to eq [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }]
+    end
+
+    it 'parses a JSON response with an unspecified content_type' do
+      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+      stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+        .to_return(
+          body: [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }].to_json
+        )
+
+      result = json_api.get('properties?postcode=A1 1AA')
+
+      expect(result).to eq [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }]
+    end
+
+    it 'raises an exception for an invalid json response' do
+      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+      stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+        .to_return(
+          body: '<html><body>An error occurred</body></html>'
+        )
+
+      expect { json_api.get('properties?postcode=A1 1AA') }
+        .to raise_error(JsonApi::InvalidResponseError, "765: unexpected token at '<html><body>An error occurred</body></html>'")
+    end
+
+    it 'handles an empty response body' do
+      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+      stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+
+      result = json_api.get('properties?postcode=A1 1AA')
+
+      expect(result).to eq nil
     end
   end
 

--- a/spec/support/test_ssl.rb
+++ b/spec/support/test_ssl.rb
@@ -1,0 +1,107 @@
+module TestSsl
+  # A real SSL certificate and key for testing purposes
+  #
+  # Generated mostly in the same way as the real certs:
+  #
+  # Generate the key:
+  #   openssl genrsa -des3 -out test.key 4096
+  #
+  # Strip the password from the key:
+  #   openssl rsa -in test.key -out test.key
+  #
+  # Generate a signing request:
+  #   openssl req -new -key test.key -out test.csr
+  #
+  # Sign the cert (for the real certs this part was done by dxw ops)
+  #   openssl x509 -req -sha256 -days 3650 -in test.csr -signkey test.key -out test.crt
+
+  def self.key
+    <<~EOF
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIJKgIBAAKCAgEAzTxqml+dWPWsS0bvT6wYp5/TJIsDMYjBi9iUcYuLXWtRx0Po
+      qWXeTDvgIcv7Lj7QMNQguhK+0cCGJPXOztxqbn85mw94vUw0TVSO6ZkAEb9sOpdr
+      waSfqc8irfeCUwJ3O5xzsStGcTYrLEXsThvuFxu0F98vmI3pwVXTirM7c7/SmIpd
+      aRABCuFbp5KuB9/lWWSqCmArXhYTW61dREep67W5/CnobxCFGa/OToE5usjMJjiW
+      XNGwQ7j9wtHDZgf24b6wKz06/f6yb1NpSlNB1ObePvxSHpz1c3cmtHvb48mEpyQd
+      shoD8QOdhqwfqJJhG707e3YFQCROiWY5aFsE7WP4no1hA/fUUaLv31tPkbADAXON
+      yzq+k4YZeBZG4xquCHkBl9bqp5KiSnk40V/TYrpQqtK3afB/FhcXF5dlJ6DEvfGz
+      rVJlCXwkaZzk2g9hglSNOBMz31+n8Pp4K1KWVpCH+rTTksTy7rTtqAmV5gJJUMg4
+      8gR8q7TDJGSkrpOQO+38l8xUdAfHVHrXVV2DF+DNPAymZ5x6vMgI4c0JoGjlS/Au
+      EhXGVtOsrneWcjPkfkYBj/D7WUFueIxEU72odnW6w9QVB+g2Ty46o9J52296/MPg
+      D325qbryp1GWk11g5gqEX2zcI6kYg/P32lL1Hs9a3AEHnHh1WG8gSIyWWKsCAwEA
+      AQKCAgACWUSnC50TXYxhOCiY8tE9adjSvDyHHpeIcCwSuJQZt5ax/xb0iVPn7297
+      M4hmWRWs2WCegIRqhheC6MU7HM6jARW5ro2lLPAUSnlwNu4HRfeJHB6Bks649MPi
+      1chKBucyaXHxfxtJRGNuGEbCBhPNc+W1uDolNsqMCd1n4vE1O+a/FCZJg4NfioCw
+      BD+1m1xWj45anAsjAoGqNOuyUleheOzt89TTII9FYfusblIozw93CILAAS5ROBa/
+      WgMwcbrjjnkZpZO9QGLuXzf/P8CrHRFCC0UtUIKGlcB9pEU58B5ygzlLxnxxD6eH
+      2QRru3EdDidWHF2nBENZ0y+pABGoWIvwtUGFscHFidcq1Xa4qeTN+fy1bukbzDcF
+      OYH9b+USkM6RcQ++8XaGgbNP0QdfDufZ3GDYDTO+GmeQ6PKWkFmL9YAeSXESSp9d
+      8RyFewpXxlgY5u04k9/wX9lwUTV6eW8whzryx3HIay2fu9cawAam4kNr/8BAgQdz
+      bT/cOgdrpZsC0qBjuaDpz+/rT6Up5xLxgTudE3PpOHi8Pzf0c0U8UAbmyYbLWVLA
+      dbv+D8HHKWiSSiwPDpofSkPR8T/BVyWAr8UUIjZfjeGXsY+gu8wUJ6i1MkmUOWru
+      fPcfZaPkOaEZtaESrSnWgHc/SPF41K8BB6533SnyhNu2q3eU0QKCAQEA/s7t/c1i
+      5n/5Q9KqEqzecK7M63nsHqodDCverBPNF1iS112FpIpMMwkrTQdITad8Jw104pre
+      oy2kLeEK3KzdTH479PClKSoCoaGFRnzNUKIlF0YzwvUK3W67MSQ6+2XD/+cts+oj
+      t2oacn3VK/+NUYhy4RKYfC2lMZ5y3ULLhTnvqMB9VFZYAVHaA/fLTV+ArGqQipES
+      aQeGvKTK+iYJIuK8rgG42C/l5C4J09rB5lLXqwPTNtkcAhWVejH9XdY6oqPf0t/m
+      a69XG36ztv5kSCyHaBMc6dQvMyCNDnQPD3vqBtNbe9e0g0NAFetGrs5K+eFkDobi
+      5Jzt/kkpv9r9vwKCAQEAzjIi1y2WZB1KKv2TRr1H29dSTHOkh8GeTUaJiIFFKAYc
+      7Qen08NXjCcgdfvFB4aqZ/G2M3R2H6ZVMFJF5eYyHZ/U6k2vkIhCWZqXty/eeSz+
+      y/+YGkXTc7YNlNOKZvX4p0VWE4XC4wRwQxrcmxUe9egmosdel+yiZ9ogkIAaY8p2
+      Pt2/zDq/LScpno89wMmiC9G/PszdXs3Go6QDuY+8ZuKd2KDOg1zMX2rreJIdnX7n
+      vIhr6yqxwgRF7NQk23yy+8L6x/GUaprYlWopvYGCRb/MJZNPw2sbTLeCvtSRsn1D
+      26Tz/biNyX9dBbq95sttYXo/vA+OsfJ3Iu/bftJ4FQKCAQEA4upvAPX2HGVdGywx
+      Lx5pnZndfdp/DzPZWGx9CWs82oyTgF2V1Vkf0Ndai2dv2U/M/Y47SE449MKBkiX2
+      IV2EWkmUpWXk/4qc+0m3QXWE9kjflSF8mSLVwSqKY5HrQNR4vp0mkzFxCzbfRJSQ
+      0XTsae6Et7FywCt6EH0Vt7tzOTrGFdcOBZw7FTnKWHxEvavOED16aRwWdBgywi5T
+      YH+c5UdcVe3MqiHFrfXd5J/My4t86pwmbZLdIXINQtvf0cAlSY98lPO15LIqdZ7Y
+      9p8HuUqGb4WN2yKNwg877uImQ1jLqbZxoxEOfVLXcG2s7aFjHbK+Az3WM1cZjrmj
+      B2tDSwKCAQEAqn+cfY8tjyUFAh1hnZnABJG8dIkfID5ClqVf7ibuN1Uur/Snmpwp
+      FTP5THXeCwYYfBDLVyrSzgLs6CLvt1UsVYCnPwLzzDBPpOYG06vaaxqAqdB0Ri08
+      1q5P9qMhC1gSvsW/ki8F4k/2QBbDGd1SF4ZaBDmVB0zdUcB1Mucqax+rvPoBsW9W
+      S5DZgknxhytzOhC68cPWvKCswv1JMzQeVnjGiq0VdlvShofTo4Q2xtd76VJo4jEQ
+      gVylMVqOC4vGOBWW5qPk1G2r74i0cQXY4bHhraRszSsQjNQlYYRF4XBhHwr70e28
+      GESfd7BdfKzziina77dxh8T1LEdnmSuRrQKCAQEAzImumN//qpT8KY601ljx53MJ
+      8IFoTE5kubvjyak5+4+DYZwKgf1NLkHQJlb8Jcs/IKUO+ASV/++F16vxS4Wc+F8a
+      WqLRc2Q1ZhE6Q1JcgJQviS1VaguqJD5ioAdT+wr15Eb0qkW+M0LI1K9ZTW+T5Oy5
+      h0CBM+WLdYxr3E6wtupEgAvYpapGRXgoigSCQNs9U41SlRKBeUNKZGgudEwVvPnR
+      PsVcQIHuKMWQlxoeWaYhmD2U64lzUXUPxLwkl7lbaWGbAszvFC7UqMn3BCVPCnOI
+      LsNdmUgH5J6+ZRlGkDjvsmeOXuRQznssp/M3WiKhA1V+rZUhiEpF2IzIR4+wzw==
+      -----END RSA PRIVATE KEY-----
+    EOF
+  end
+
+  def self.certificate
+    <<~EOF
+      -----BEGIN CERTIFICATE-----
+        MIIFBjCCAu4CCQDmS4ztMeTTYDANBgkqhkiG9w0BAQsFADBFMQswCQYDVQQGEwJB
+      VTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0
+      cyBQdHkgTHRkMB4XDTE3MTAyNjIwMjE1OVoXDTI3MTAyNDIwMjE1OVowRTELMAkG
+      A1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0
+      IFdpZGdpdHMgUHR5IEx0ZDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
+      AM08appfnVj1rEtG70+sGKef0ySLAzGIwYvYlHGLi11rUcdD6Kll3kw74CHL+y4+
+        0DDUILoSvtHAhiT1zs7cam5/OZsPeL1MNE1UjumZABG/bDqXa8Gkn6nPIq33glMC
+      dzucc7ErRnE2KyxF7E4b7hcbtBffL5iN6cFV04qzO3O/0piKXWkQAQrhW6eSrgff
+      5VlkqgpgK14WE1utXURHqeu1ufwp6G8QhRmvzk6BObrIzCY4llzRsEO4/cLRw2YH
+      9uG+sCs9Ov3+sm9TaUpTQdTm3j78Uh6c9XN3JrR72+PJhKckHbIaA/EDnYasH6iS
+      YRu9O3t2BUAkTolmOWhbBO1j+J6NYQP31FGi799bT5GwAwFzjcs6vpOGGXgWRuMa
+      rgh5AZfW6qeSokp5ONFf02K6UKrSt2nwfxYXFxeXZSegxL3xs61SZQl8JGmc5NoP
+      YYJUjTgTM99fp/D6eCtSllaQh/q005LE8u607agJleYCSVDIOPIEfKu0wyRkpK6T
+      kDvt/JfMVHQHx1R611VdgxfgzTwMpmecerzICOHNCaBo5UvwLhIVxlbTrK53lnIz
+      5H5GAY/w+1lBbniMRFO9qHZ1usPUFQfoNk8uOqPSedtvevzD4A99uam68qdRlpNd
+      YOYKhF9s3COpGIPz99pS9R7PWtwBB5x4dVhvIEiMllirAgMBAAEwDQYJKoZIhvcN
+      AQELBQADggIBAFns233S9DipBKBCVBw+OUXJwxaNId8x2m+frr1hH0NNf+aCNEIP
+      IfofFekm5wEm5F3BF5snv2H1MKgh6LTg+6LUf6hIyKADr+OufJ108UvpImOMsfSd
+      BtO259h2pjE8+6qW62Ivgwnt8aVGxHef/c3h0pbn5oo9crZ/oSZ9XYKNE77iBuun
+      uByZkKLat5d5eb5PjxvgkXWFq2LkRoFxZB+Df2gMTK2SNNm3G4/N8m+e9w2KvJmn
+      HsBz/3YptjNFnhEskG7K33gEbrnQ87IDXHockUz6EiQOngbrHarj9psL8UZ7d6oe
+      kvdEbNTUfsuL4ntIAK0kcExTrjt7OdKCDS1M/O/IixgSwDALeXNHVOtRLSIdfhLC
+      9J4vbm9tRUyN85s6LhhylQNXVlc6zWg27VrzBmc/1ddCLFy+G41asoIz9LEPhhQs
+      VXITcE2zHwgIFj9upTrayH73jODSC5HpQzdsI+DI37pYlO6MTBTIUO+/9roDvJYh
+      dz3QPmsaqveyDCu4WXv2I2FRbFg0SGYrHQVRjXCt7cmeZvdyvc9lhafpQASFqjJF
+      7cfFIudj1pWYqYGGrdYi02em0mAWGfNWQNx8wrkpuFuKiABUDXOdAK9ju9FQmThx
+      1P8u65W3kAsHeVmtdQJNO11smWuhDEKRR/+eY1/8RfXBIdfTHDhPC1LO
+      -----END CERTIFICATE-----
+    EOF
+  end
+end


### PR DESCRIPTION
API requests are made with client certs.

This can't really be tested for real until the API access has been sorted out.

- Largely this is about allowing Faraday to be configured via environment variables
- Agreed with Leeky to skip testing that the client certs are actually used. This is unfortunate but we couldn't see how to do it, and if it doesn't work then we'll know very quickly since no requests will work.
- For completeness: I also considered applying the pattern of creating a 'Configuration' object which responds to methods, rather than being accessed like a Hash (which is the case with ENV). This would give us some protection against eg. typos in variable names, but is slightly more involved to work with (eg. in tests we'd need to pass in an object rather than a hash of params), so didn't seem worth it.