### PR TITLE
(184) Update 'describe repair' forms and page content

### DIFF
--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -7,19 +7,28 @@ module Questions
     def submit
       @form = StartForm.new(start_form_params)
 
-      return render :index unless @form.valid?
+      return render :index if @form.invalid?
 
-      if @form.priority_repair?
-        return redirect_to page_path('emergency_contact')
-      end
+      next_page = case @form.answer
+                  when 'smell_gas'
+                    page_path('gas')
+                  when 'no_heating'
+                    page_path('heating_repairs')
+                  when 'home_adaptations'
+                    page_path('home_adaptations')
+                  when 'none_of_the_above'
+                    questions_path('location')
+                  else
+                    page_path('emergency_contact')
+                  end
 
-      redirect_to questions_path('location')
+      redirect_to next_page
     end
 
     private
 
     def start_form_params
-      params.require(:start_form).permit!
+      params.require(:start_form).permit(:answer)
     end
   end
 end

--- a/app/models/start_form.rb
+++ b/app/models/start_form.rb
@@ -2,6 +2,7 @@ class StartForm
   include ActiveModel::Model
 
   attr_reader :answer
+  attr_reader :choices
 
   validates :answer, presence: true
 
@@ -9,7 +10,16 @@ class StartForm
     @answer = hash[:answer]
   end
 
-  def priority_repair?
-    answer == 'yes'
+  def choices
+    %i[
+      smell_gas
+      no_heating
+      no_water
+      no_power
+      water_leak
+      not_secure_access
+      home_adaptations
+      none_of_the_above
+    ]
   end
 end

--- a/app/views/describe_repair/_communal_blocked_drain.html.haml
+++ b/app/views/describe_repair/_communal_blocked_drain.html.haml
@@ -1,0 +1,14 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the drain or gully
+  %li
+    whether there is any obvious damage
+  %li
+    the location of the problem (nearest property or floor number)
+

--- a/app/views/describe_repair/_communal_boiler.html.haml
+++ b/app/views/describe_repair/_communal_boiler.html.haml
@@ -1,0 +1,2 @@
+%h1
+  Please let us know any additional details you think might help us

--- a/app/views/describe_repair/_communal_describe_repair.html.haml
+++ b/app/views/describe_repair/_communal_describe_repair.html.haml
@@ -1,0 +1,14 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of repair problem
+  %li
+    how the problem is affecting residents
+  %li
+    where the problem is located (the nearest property or floor number)
+

--- a/app/views/describe_repair/_communal_faulty_lamp_post.html.haml
+++ b/app/views/describe_repair/_communal_faulty_lamp_post.html.haml
@@ -1,0 +1,13 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the location of the street light
+  %li
+    the street light reference number (if known)
+  %li
+    whether there is any obvious damage to the street light

--- a/app/views/describe_repair/_communal_intercom.html.haml
+++ b/app/views/describe_repair/_communal_intercom.html.haml
@@ -1,0 +1,13 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the intercom
+  %li
+    whether there is any obvious damage to the intercom unit
+    (either in your home or door entry)
+

--- a/app/views/describe_repair/_communal_lift.html.haml
+++ b/app/views/describe_repair/_communal_lift.html.haml
@@ -1,0 +1,13 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the lift
+  %li
+    whether there is any obvious damage to the lift
+  %li
+    the location of the faulty lift

--- a/app/views/describe_repair/_communal_main_entrance_door.html.haml
+++ b/app/views/describe_repair/_communal_main_entrance_door.html.haml
@@ -1,0 +1,14 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the door
+  %li
+    whether there is any obvious damage to the door
+  %li
+    the location of the door (if there are multiple access doors)
+

--- a/app/views/describe_repair/_communal_pests.html.haml
+++ b/app/views/describe_repair/_communal_pests.html.haml
@@ -1,12 +1,10 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
-  %li
-    whether there is any obvious damage to the item
+    where you have spotted pests or rodents within the communal grounds
+

--- a/app/views/describe_repair/_communal_rubbish_chute.html.haml
+++ b/app/views/describe_repair/_communal_rubbish_chute.html.haml
@@ -1,0 +1,13 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the rubbish chute
+  %li
+    whether there is any obvious damage to the chute
+  %li
+    the location of the rubbish chute

--- a/app/views/describe_repair/_inside_bathroom_basin_leaking.html.haml
+++ b/app/views/describe_repair/_inside_bathroom_basin_leaking.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    where the leak appear to be coming from
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage to the basin
+

--- a/app/views/describe_repair/_inside_bathroom_bath_leaking.html.haml
+++ b/app/views/describe_repair/_inside_bathroom_bath_leaking.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    where the leak appears to be coming from
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage to the bath
+

--- a/app/views/describe_repair/_inside_bathroom_toilet_damaged.html.haml
+++ b/app/views/describe_repair/_inside_bathroom_toilet_damaged.html.haml
@@ -1,12 +1,10 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
-  %li
-    whether there is any obvious damage to the item
+    how the toilet is damaged
+

--- a/app/views/describe_repair/_inside_bathroom_toilet_leaking.html.haml
+++ b/app/views/describe_repair/_inside_bathroom_toilet_leaking.html.haml
@@ -1,12 +1,13 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    where the leak appears to be coming from
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage to the toilet
+
+

--- a/app/views/describe_repair/_inside_boiler.html.haml
+++ b/app/views/describe_repair/_inside_boiler.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    whether there is an error message on your boiler
   %li
-    whether there is any obvious damage to the item
+    if the problem has happened previously
+

--- a/app/views/describe_repair/_inside_kitchen_broken_tap.html.haml
+++ b/app/views/describe_repair/_inside_kitchen_broken_tap.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    how the tap is broken
   %li
-    whether there is any obvious damage to the item
+    the type of tap, if you know it - for example, pillar or mixer
+

--- a/app/views/describe_repair/_inside_kitchen_cupboards.html.haml
+++ b/app/views/describe_repair/_inside_kitchen_cupboards.html.haml
@@ -1,0 +1,13 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of repair problem with your cupboards or worktop
+  %li
+    the finish/colour of your kitchen cupboards or worktop (if known)
+
+

--- a/app/views/describe_repair/_inside_kitchen_extractor_fan.html.haml
+++ b/app/views/describe_repair/_inside_kitchen_extractor_fan.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    the type of problem with your extractor fan
   %li
-    whether there is any obvious damage to the item
+    whether there are any obvious signs of damage
+

--- a/app/views/describe_repair/_inside_kitchen_light_fitting.html.haml
+++ b/app/views/describe_repair/_inside_kitchen_light_fitting.html.haml
@@ -1,12 +1,13 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    the type of problem with the light fitting
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage
+
+

--- a/app/views/describe_repair/_inside_kitchen_light_switch.html.haml
+++ b/app/views/describe_repair/_inside_kitchen_light_switch.html.haml
@@ -1,12 +1,11 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    the type of problem with the light switch
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage to the switch

--- a/app/views/describe_repair/_inside_kitchen_sink_leaking.html.haml
+++ b/app/views/describe_repair/_inside_kitchen_sink_leaking.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    where the leak appear to be coming from
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage to the sink
+

--- a/app/views/describe_repair/_inside_sockets.html.haml
+++ b/app/views/describe_repair/_inside_sockets.html.haml
@@ -1,12 +1,13 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    the type of problem with the socket
   %li
-    whether there is any obvious damage to the item
+    whether it is a single or double socket
+
+

--- a/app/views/describe_repair/_inside_window_damage.html.haml
+++ b/app/views/describe_repair/_inside_window_damage.html.haml
@@ -1,0 +1,15 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    how is the glass damaged
+  %li
+    how the damage occurred
+  %li
+    whether you have a crime reference number (if the
+    window has been vandalised)
+

--- a/app/views/describe_repair/_inside_window_not_shutting.html.haml
+++ b/app/views/describe_repair/_inside_window_not_shutting.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    the type of problem with the window
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage
+

--- a/app/views/describe_repair/_other_external_door_lock.html.haml
+++ b/app/views/describe_repair/_other_external_door_lock.html.haml
@@ -1,12 +1,12 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    the type of problem with the lock
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage to the lock
+

--- a/app/views/describe_repair/_other_external_door_stiff.html.haml
+++ b/app/views/describe_repair/_other_external_door_stiff.html.haml
@@ -1,12 +1,11 @@
 %h1
   Please let us know any additional details you think might help us
 
-
 %p
   Please describe:
 
 %ul
   %li
-    the type of problem
+    how the movement of the door is affected
   %li
-    whether there is any obvious damage to the item
+    whether there is any obvious damage to the door

--- a/app/views/describe_repair/_other_internal_door.html.haml
+++ b/app/views/describe_repair/_other_internal_door.html.haml
@@ -1,0 +1,15 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the door
+  %li
+    where the door is located
+  %li
+    whether there is any obvious damage to the door
+
+

--- a/app/views/describe_repair/_outside_describe_repair.html.haml
+++ b/app/views/describe_repair/_outside_describe_repair.html.haml
@@ -1,0 +1,18 @@
+%h1
+  What is the problem outside your home?
+
+%ul
+  %li
+    the guttering or downpipe is blocked or damaged
+  %li
+    a drain is blocked
+  %li
+    paving is broken or coming loose
+  %li
+    the roof is leaking - containable
+  %li
+    a light is not working
+  %li
+    I have pest or rodents in or near my home
+  %li
+    something else

--- a/app/views/describe_repair/_outside_drain.html.haml
+++ b/app/views/describe_repair/_outside_drain.html.haml
@@ -1,0 +1,16 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the drain or gully
+  %li
+    whether there is any obvious damage
+  %li
+    the location of the problem, such as the nearest property or which floor it's on
+
+
+

--- a/app/views/describe_repair/_outside_guttering.html.haml
+++ b/app/views/describe_repair/_outside_guttering.html.haml
@@ -1,0 +1,19 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the guttering or downpipe
+  %li
+    whether there is any obvious damage
+  %li
+    the material it's made from (for example: cast iron, plastic)
+  %li
+    the location of the problem, such as nearest property or floor number
+
+
+
+

--- a/app/views/describe_repair/_outside_paving.html.haml
+++ b/app/views/describe_repair/_outside_paving.html.haml
@@ -1,0 +1,15 @@
+%h1
+  Please let us know any additional details you think might help us
+
+%p
+  Please describe:
+
+%ul
+  %li
+    the type of problem with the paving
+  %li
+    whether there is any obvious damage
+  %li
+    the location of the problem, such as the courtyard or garden
+
+

--- a/app/views/pages/carbon_monoxide_alarm.html.haml
+++ b/app/views/pages/carbon_monoxide_alarm.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   Carbon Monoxide Alarm
 

--- a/app/views/pages/carbon_monoxide_alarm.html.haml
+++ b/app/views/pages/carbon_monoxide_alarm.html.haml
@@ -1,0 +1,24 @@
+%h1
+  Carbon Monoxide Alarm
+
+%h2
+  What to do if your carbon monoxide (CO) alarm has triggered
+
+%ol
+  %li
+    Turn off the gas supply at the gas meter
+  %li
+    Extinguish all sources of ignition
+  %li
+    Do not smoke
+  %li
+    Do not operate electrical light switches and power sockets
+  %li
+    Do not use the door entry system, if you are granting anyone access, go down to the entrance door to let them in
+  %li
+    Open doors and windows to ventilate the area
+  %li
+    Contact National Grid on
+    %strong
+      0800 111 999
+    from outside the property

--- a/app/views/pages/check_fusebox.html.haml
+++ b/app/views/pages/check_fusebox.html.haml
@@ -1,7 +1,27 @@
 = back_link
 
 %h1
-  Check your fusebox
+  Checking the fuse box
 
 %p
-  Instructions to help the resident locate and check their fusebox.
+  If your light is not working, it may be that the corresponding trip switch
+  in your fuse box is not in the correct position. Please check your fuse
+  box and ensure that the switch is in the 'ON' position.
+
+%p
+  The fuse box is typically located in the hallway cupboard. If you would
+  like help locating the fuse box in your home, please call the repairs
+  contact centre on 020 8356 2300.
+
+%p
+  %strong
+    Warning:
+  If you are replacing any light bulbs in your home, please ensure you have
+  flicked the relevant trip switch to the 'OFF' position.
+  If you have any doubts, please contact us for guidance.
+
+%p
+  If you have checked the switch and the light is still not working, please
+  select continue to book an appointment
+
+%p= link_to 'Continue', describe_repair_path, class: 'button'

--- a/app/views/pages/cleaners_responsibility.html.haml
+++ b/app/views/pages/cleaners_responsibility.html.haml
@@ -1,1 +1,3 @@
+= back_link
+
 %h1 Please raise this issue with the cleaner

--- a/app/views/pages/damp_and_mould.html.haml
+++ b/app/views/pages/damp_and_mould.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   Damp & mould
 

--- a/app/views/pages/damp_and_mould.html.haml
+++ b/app/views/pages/damp_and_mould.html.haml
@@ -1,0 +1,17 @@
+%h1
+  Damp & mould
+
+%h2
+  How to tackle damp and mould in your home
+
+%p
+  Watch this brief video that provides guidance on dealing
+  with damp and mould problem areas in your home.
+
+%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/7nq71pGBGI8?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+
+%p
+  Select continue if you would to progress with reporting this repair.
+
+%p= link_to 'Continue', describe_repair_path(details: 'damp'), class: 'button'
+

--- a/app/views/pages/electrical_hazard_warning.html.haml
+++ b/app/views/pages/electrical_hazard_warning.html.haml
@@ -1,5 +1,18 @@
-%h1 Warning
+%h1 Electrical safety
 
-%p Please do not touch any electrical fittings, and if possible please switch off power to your home.
+%p
+  %strong
+    Please exercise extreme caution with any faulty or exposed electrics
+    in your home and make sure that the area is restricted for any
+    household members.
+
+%p
+  If you are uncertain or have any immediate concerns about an electrical
+  repair issue in your home, please call our repairs contact centre for
+  guidance on 020 8356 2300.
+
+%p
+  If you would like to book an appointment for your electrical repair,
+  please select continue.
 
 %p= link_to 'Continue', describe_repair_path, class: 'button'

--- a/app/views/pages/electrical_hazard_warning.html.haml
+++ b/app/views/pages/electrical_hazard_warning.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1 Electrical safety
 
 %p

--- a/app/views/pages/gas.html.haml
+++ b/app/views/pages/gas.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   What to do if you smell gas
 

--- a/app/views/pages/gas.html.haml
+++ b/app/views/pages/gas.html.haml
@@ -1,0 +1,21 @@
+%h1
+  What to do if you smell gas
+
+%ol
+  %li
+    Turn off the gas supply at the gas meter
+  %li
+    Extinguish all sources of ignition
+  %li
+    Do not smoke
+  %li
+    Do not operate electrical light switches and power sockets
+  %li
+    Do not use the door entry system, if you are granting anyone access, go down to the entrance door to let them in
+  %li
+    Open doors and windows to ventilate the area
+  %li
+    Contact National Grid on
+    %strong
+      0800 111 999
+    from outside the property

--- a/app/views/pages/heating_repairs.html.haml
+++ b/app/views/pages/heating_repairs.html.haml
@@ -1,0 +1,19 @@
+%h1
+  Heating repairs
+
+%h2
+  Watch this short video to find out how to fix common heating problems.
+
+%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/ktklk7d0ibY?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+
+%p
+  If your heating still isn't working, please call our repairs contact
+  centre so that we can help resolve this and schedule a
+  suitable appointment.
+
+%p
+  Please call the repairs contact centre on
+  %strong
+    020 8356 2300
+  Monday&ndash;Friday 8am&ndash;7pm and
+  Saturday 9am&ndash;1pm.

--- a/app/views/pages/heating_repairs.html.haml
+++ b/app/views/pages/heating_repairs.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   Heating repairs
 

--- a/app/views/pages/home_adaptations.html.haml
+++ b/app/views/pages/home_adaptations.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   Disabilities and home adaptations
 

--- a/app/views/pages/home_adaptations.html.haml
+++ b/app/views/pages/home_adaptations.html.haml
@@ -1,0 +1,16 @@
+%h1
+  Disabilities and home adaptations
+
+%p
+  If you're reporting a repair to your home where it has been altered or
+  adapted to better meet your needs due to a disability, please call our
+  repairs contact centre so we can review your repair immediately and
+  schedule a suitable appointment.
+
+%p
+  Please call the repairs contact centre on
+  %strong
+    020 8356 2300
+  Monday&ndash;Friday 8am&ndash;7pm and
+  Saturday 9am&ndash;1pm.
+

--- a/app/views/pages/kitchen_sink_unblock_info.html.haml
+++ b/app/views/pages/kitchen_sink_unblock_info.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   Sink blocked?
 

--- a/app/views/pages/repair_your_responsibility.html.haml
+++ b/app/views/pages/repair_your_responsibility.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   You are responsible for repairing this problem
 

--- a/app/views/pages/replace_lightbulb.html.haml
+++ b/app/views/pages/replace_lightbulb.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   Common fixes - replacing a lightbulb
 

--- a/app/views/pages/replace_lightbulb.html.haml
+++ b/app/views/pages/replace_lightbulb.html.haml
@@ -1,15 +1,11 @@
 %h1
   Common fixes - replacing a lightbulb
 
-%h2
-  How to replace a light bulb
+%p
+  Watch this brief video that provides guidance on how to replace a light bulb or a lamp in your home.
 
 %p
-  Watch this brief video to learn how to replace a bathroom light bulb or lamp.
-
-%p
-  The guidance in this video is also applicable for replacing light bulbs
-  in other areas of your home.
+  The guidance in this video is also applicable for replacing light bulbs in other areas of your home.
 
 %iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/NZN2AZAMPHY?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
 

--- a/app/views/pages/smoke_detector.html.haml
+++ b/app/views/pages/smoke_detector.html.haml
@@ -1,14 +1,11 @@
-= back_link
-
 %h1
-  Emergency repairs
-
-%h2
-  The problem you're having may need immediate attention
+  Smoke detector beeping
 
 %p
-  We ask that you report Emergency and Immediate repair problems through our Repairs Contact Centre.
-  This will allow us to review your repair straight away and schedule a suitable appointment to help resolve the issue quickly.
+  If your smoke detector or fire alarm is beeping please call the
+  repairs contact centre. This will allow us to review the problem
+  as a priority and schedule a suitable appointment to help
+  resolve the issue quickly.
 
 %p
   %strong
@@ -26,7 +23,7 @@
   damage to your property, please call:
   %strong
     %span{ itemprop: 'telephone' }
-      %a{ href: 'tel:02083562300' }020 8356 2300
+      %a{ href: 'tel:02083562300' } 020 8356 2300
 
 %p
   %strong
@@ -42,6 +39,6 @@
 
 %p
   %strong
-    For gas:
+    For gas, call National Grid:
   %span{ itemprop: 'telephone' }
     %a{ href: 'tel:0800111999' } 0800 111 999

--- a/app/views/pages/smoke_detector.html.haml
+++ b/app/views/pages/smoke_detector.html.haml
@@ -1,3 +1,5 @@
+= back_link
+
 %h1
   Smoke detector beeping
 

--- a/app/views/pages/start.html.haml
+++ b/app/views/pages/start.html.haml
@@ -2,16 +2,17 @@
   Report a repair
 
 %p.lede
-  We provide housing and communal area repairs for our Hackney residents.
+  We provide housing and communal area repairs for council tenants,
+  and communal repairs for leaseholders.
 
 %p
   You can use this service to:
 
 %ul
   %li
-    report the most common problems with your home
+    report non-emergency repairs to your home
   %li
-    learn how to solve common repair types with how-to videos
+    choose a date and time for us to carry out the repair
 
 %p
   Reporting a repair should take around 5 minutes.
@@ -32,12 +33,33 @@
   %a.button.button-start{ href: '/questions/start/' } Start
 
 %h2
-  Before you start
+  Emergency and urgent repairs
 
 %p
-  You are responsible for any home improvements you have carried out yourself.
+  If your repair is an emergency, please call the
+  Repairs Contact Centre on
+  %span{ itemprop: 'telephone' }
+    = succeed '.' do
+      %a{ href: 'tel:02083563691' } 020 8356 3691
 
 %p
-  If your home is managed by a
-  %abbr{ title: 'Tenant Management Organisation' } TMO
-  please contact them first for help with repairs.
+  They are open
+  %strong
+    Monday&ndash;Friday, 8am&ndash;7pm
+  and
+  %strong
+    Saturday, 9am&ndash;1pm
+
+%h2
+  Home improvements
+
+%p
+  Please note, you are responsible for any home improvements you carry
+  out yourself.
+
+%h2
+  Tenant Management Organisation (TMO)
+
+%p
+  If your home is managed by a TMO, please contact them first for
+  help with repairs.

--- a/app/views/pages/toilet_unblock_info.html.haml
+++ b/app/views/pages/toilet_unblock_info.html.haml
@@ -1,8 +1,21 @@
-%h1 Toilet blocked?
+= back_link
 
-%p It's pretty straightforward to unblock a toilet, you'll need:
+%h1
+  Common repairs - unblock toilet
 
-%ul
-  %li A large bin bag
-  %li A mop
+%h2
+  Watch this brief video to find out how to unblock your toilet
 
+%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/_zzMhYpaD-o?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+
+%p
+  If your toilet is still blocked, please call our repairs contact
+  centre so that we can help resolve this and schedule a
+  suitable appointment.
+
+%p
+  Please call the repairs contact centre on
+  %strong
+    020 8356 2300
+  Monday&ndash;Friday 8am&ndash;7pm and
+  Saturday 9am&ndash;1pm.

--- a/app/views/questions/start/index.html.haml
+++ b/app/views/questions/start/index.html.haml
@@ -1,16 +1,17 @@
 = simple_form_for @form, url: request.fullpath do |f|
   %fieldset
     %legend.question
-      %h1 Before we start
+      %h1 Before you continue
 
       %p
         %strong
-          Do any of the following apply to you:
+          Do any of the following apply:
 
       %ul
-        %li I have no electricity
-        %li I have no water
+        %li I can smell gas
         %li I have no heating
+        %li I have no water
+        %li I have no power
         %li I have a water leak which I cannot contain
         %li I cannot access my property
 

--- a/app/views/questions/start/index.html.haml
+++ b/app/views/questions/start/index.html.haml
@@ -7,20 +7,6 @@
         %strong
           Do any of the following apply:
 
-      %ul
-        %li I can smell gas
-        %li I have no heating
-        %li I have no water
-        %li I have no power
-        %li I have a water leak which I cannot contain
-        %li I cannot access my property
-
-      %p
-        or
-
-      %ul
-        %li my home has been adapted for my disability
-
     .answers
-      = f.input :answer, collection: [:yes, :no], as: :radio_buttons, label: false
+      = f.input :answer, collection: @form.choices, as: :radio_buttons, label: false
       = f.button :submit, class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,12 @@ en:
           afternoon: "afternoon (12pm - 5pm)"
       start_form:
         answer:
-          'yes': 'Yes'
-          'no': 'No'
+          smell_gas: I can smell gas
+          no_heating: I have no heating
+          no_water: I have no water
+          no_power: I have no power
+          water_leak: I have a water leak which I cannot contain
+          not_secure_access: I cannot secure access to my property
+          home_adaptations: My home has been adapted for my disability
+          none_of_the_above: No, my problem is not one of the above
   title: Report a repair

--- a/db/questions.yml
+++ b/db/questions.yml
@@ -15,34 +15,52 @@ communal_problem:
   question: What is the problem in the communal grounds?
   answers:
     - text: A light is not working
-      next: faulty_lamp_post
+      desc: communal_faulty_lamp_post
 
     - text: The main entrance door is damaged or not closing
+      desc: communal_main_entrance_door
+
     - text: The intercom is not working for my property
+      desc: communal_intercom
+
     - text: The lift is faulty
+      desc: communal_lift
+
     - text: The rubbish chute is blocked or damaged
+      desc: communal_rubbish_chute
+
     - text: There is a blocked drain or gully
+      desc: communal_blocked_drain
+
     - text: There are pests or rodents
+      desc: communal_pests
+
     - text: Something else
-
-faulty_lamp_post:
-  question: Are you reporting a faulty lamp post?
-  answers:
-    - text: 'Yes'
-
-    - text: 'No'
-      page: cleaners_responsibility
+      desc: communal_describe_repair
 
 outside_problem:
   question: What is the problem outside your home?
   answers:
     - text: The guttering or downpipe is blocked or damaged
+      desc: outside_guttering
+
     - text: A drain is blocked
+      desc: outside_drain
+
     - text: Paving is broken or coming loose
+      desc: outside_paving
+
     - text: The roof is leaking
+      desc: outside_describe_repair
+
     - text: A light is not working
+      desc: outside_describe_repair
+
     - text: I have pests or rodents in or near my home
+      desc: communal_pests
+
     - text: Something else
+      desc: outside_describe_repair
 
 which_room:
   question: Which room?
@@ -60,9 +78,10 @@ kitchen_problem:
   question: What is the problem in your kitchen?
   answers:
     - text: Cupboards or Worktop
+      desc: inside_kitchen_cupboards
 
     - text: Damp or Mould
-      desc: damp
+      page: damp_and_mould
 
     - text: Electrical
       next: kitchen_electrical_problem
@@ -89,13 +108,13 @@ kitchen_electrical_problem:
       next: water_leaking_into_light
 
     - text: Light switch
-      page: electrical_hazard_warning
+      desc: inside_kitchen_light_switch
 
     - text: Smoke detector is beeping
-      page: emergency_contact
+      page: smoke_detector
 
     - text: Sockets
-      page: electrical_hazard_warning
+      desc: inside_sockets
 
     - text: Something else
       desc: kitchen_problem
@@ -104,8 +123,10 @@ heating_problem:
   question: Is your problem one of these?
   answers:
     - text: I have no hot water - boiler in my home
+      desc: inside_boiler
 
     - text: I have no hot water - communal boiler
+      desc: communal_boiler
 
     - text: Radiator is not working
 
@@ -122,6 +143,7 @@ sink_problem:
     - text: Sink is blocked
 
     - text: Sink is leaking - containable
+      desc: inside_kitchen_sink_leaking
 
     - text: Tap won't turn off - water running
       page: emergency_contact
@@ -129,6 +151,7 @@ sink_problem:
     - text: Tap is dripping
 
     - text: Tap is broken
+      desc: inside_kitchen_broken_tap
 
     - text: Something else
       desc: sink_problem
@@ -164,6 +187,7 @@ is_fan_leaking_water:
       page: emergency_contact
 
     - text: 'No'
+      desc: inside_kitchen_extractor_fan
 
 basin_problem:
   question: Is your problem one of these?
@@ -171,6 +195,7 @@ basin_problem:
     - text: Basin / Sink is blocked
 
     - text: Basin / Sink is leaking - containable
+      desc: inside_bathroom_basin_leaking
 
     - text: Tap won't turn off - water running
       page: emergency_contact
@@ -188,6 +213,7 @@ bath_problem:
     - text: Bath is blocked
 
     - text: Bath is leaking - containable
+      desc: inside_bathroom_bath_leaking
 
     - text: Tap won't turn off - water running
       page: emergency_contact
@@ -217,7 +243,6 @@ bathroom_electrical_problem:
 other_problem:
   question: What is the problem?
   answers:
-
    - text: Damp or mould
      desc: damp
 
@@ -229,11 +254,12 @@ other_problem:
 
    - text: Gas
      page: emergency_contact
-  
+
    - text: Heating
      next: heating_problem
 
    - text: Internal door
+     desc: other_internal_door
 
    - text: Windows
      next: window_problem
@@ -270,10 +296,13 @@ window_problem:
   question: Is your problem one of these?
   answers:
     - text: Window is not shutting / locking properly - uPVC
+      desc: inside_window_not_shutting
 
     - text: Window is not shutting / locking properly - Wood
+      desc: inside_window_not_shutting
 
     - text: Damage to glazing
+      desc: inside_window_damage
 
     - text: Something else
       desc: window_problem
@@ -283,11 +312,14 @@ external_doors_problem:
   question: Is your problem one of these?
   answers:
     - text: Front or back door is stiff or loose - uPVC
+      desc: other_external_door_stiff
 
     - text: Front or back door is stiff or loose - Wood
+      desc: other_external_door_stiff
 
     - text: Door lock
-      
+      desc: other_external_door_lock
+
     - text: Something else
       desc: external_doors_problem
 
@@ -319,9 +351,11 @@ toilet_problem:
     - text: Toilet is not flushing
       page: toilet_unblock_info
 
-    - text: Toilet is cracked
+    - text: Toilet is damaged
+      desc: inside_bathroom_toilet_damaged
 
     - text: Toilet is leaking - containable
+      desc: inside_bathroom_toilet_leaking
 
     - text: Something else
       desc: toilet_problem

--- a/db/questions.yml
+++ b/db/questions.yml
@@ -29,7 +29,7 @@ communal_problem:
     - text: The rubbish chute is blocked or damaged
       desc: communal_rubbish_chute
 
-    - text: There is a blocked drain or gully
+    - text: There is a blocked or overflowing drain
       desc: communal_blocked_drain
 
     - text: There are pests or rodents
@@ -41,10 +41,10 @@ communal_problem:
 outside_problem:
   question: What is the problem outside your home?
   answers:
-    - text: The guttering or downpipe is blocked or damaged
+    - text: The guttering or downpipe is overflowing or damaged
       desc: outside_guttering
 
-    - text: A drain is blocked
+    - text: A drain is blocked or overflowing
       desc: outside_drain
 
     - text: Paving is broken or coming loose

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Questions::StartController do
+  describe '#submit' do
+    context 'shows different content based on user choice' do
+      it 'shows the gas page' do
+        post :submit, params: { start_form: { answer: 'smell_gas' } }
+
+        expect(response).to redirect_to '/pages/gas'
+      end
+
+      it 'shows the heating repairs page' do
+        post :submit, params: { start_form: { answer: 'no_heating' } }
+
+        expect(response).to redirect_to '/pages/heating_repairs'
+      end
+
+      it 'shows the home adaptations page' do
+        post :submit, params: { start_form: { answer: 'home_adaptations' } }
+
+        expect(response).to redirect_to '/pages/home_adaptations'
+      end
+
+      it 'shows the location question' do
+        post :submit, params: { start_form: { answer: 'none_of_the_above' } }
+
+        expect(response).to redirect_to '/questions/location'
+      end
+
+      it 'shows the standard emergency contact page for other values' do
+        post :submit, params: { start_form: { answer: 'xxxx' } }
+
+        expect(response).to redirect_to '/pages/emergency_contact'
+      end
+    end
+  end
+end

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -240,7 +240,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Start'
 
     # Emergency page:
-    choose_radio_button 'Yes'
+    choose_radio_button 'I can smell gas'
     click_on 'Continue'
 
     click_on t('back_link')

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     expect(page).to have_content 'What is your address?'
     click_on t('back_link')
 
-    expect(page).to have_content 'Is there anything else we should know?'
+    expect(page).to have_content 'Please let us know any additional details'
     click_on t('back_link')
 
     expect(page).to have_content 'What is the problem?'

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     expect(page).to have_content 'What is the problem?'
     click_on t('back_link')
 
-    expect(page).to have_content 'Do any of the following apply to you:'
+    expect(page).to have_content 'Do any of the following apply'
   end
 
   scenario 'when the repair could not be diagnosed' do
@@ -107,7 +107,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     expect(page).to have_content 'What is the problem?'
     click_on t('back_link')
 
-    expect(page).to have_content 'Do any of the following apply to you:'
+    expect(page).to have_content 'Do any of the following apply'
   end
 
   scenario 'when the address search was invalid' do
@@ -244,7 +244,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Continue'
 
     click_on t('back_link')
-    expect(page).to have_content 'Do any of the following apply to you:'
+    expect(page).to have_content 'Do any of the following apply'
   end
 
   scenario 'going back from the My address is not here exit page' do

--- a/spec/features/users_can_answer_repair_questions_spec.rb
+++ b/spec/features/users_can_answer_repair_questions_spec.rb
@@ -9,8 +9,13 @@ RSpec.feature 'Users can answer repair questions' do
     end
 
     within '.answers' do
-      expect(page).to have_content 'Yes'
-      expect(page).to have_content 'No'
+      expect(page).to have_content t('simple_form.options.start_form.answer.smell_gas')
+      expect(page).to have_content t('simple_form.options.start_form.answer.no_heating')
+      expect(page).to have_content t('simple_form.options.start_form.answer.no_water')
+      expect(page).to have_content t('simple_form.options.start_form.answer.no_power')
+      expect(page).to have_content t('simple_form.options.start_form.answer.water_leak')
+      expect(page).to have_content t('simple_form.options.start_form.answer.home_adaptations')
+      expect(page).to have_content t('simple_form.options.start_form.answer.none_of_the_above')
     end
 
     expect(page).to have_button t('helpers.submit.create')
@@ -26,17 +31,17 @@ RSpec.feature 'Users can answer repair questions' do
     end
   end
 
-  scenario "Users can choose 'Yes' and get shown the emergency contact page" do
+  scenario "Users can choose 'I smell gas' and get shown the relevant content" do
     visit '/questions/start/'
-    choose_radio_button t('simple_form.options.start_form.answer.yes')
+    choose_radio_button t('simple_form.options.start_form.answer.smell_gas')
     click_continue
 
-    expect(page).to have_content 'Emergency repairs'
+    expect(page).to have_content 'What to do if you smell gas'
   end
 
-  scenario "Users can choose 'No' and is shown the next question" do
+  scenario "Users can choose 'No...' and is shown the next question" do
     visit '/questions/start/'
-    choose_radio_button t('simple_form.options.start_form.answer.no')
+    choose_radio_button t('simple_form.options.start_form.answer.none_of_the_above')
     click_continue
 
     within '.question' do

--- a/spec/features/users_can_answer_repair_questions_spec.rb
+++ b/spec/features/users_can_answer_repair_questions_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Users can answer repair questions' do
     visit '/questions/start/'
 
     within '.question' do
-      expect(page).to have_content 'Do any of the following apply to you:'
+      expect(page).to have_content 'Do any of the following apply'
     end
 
     within '.answers' do
@@ -31,7 +31,7 @@ RSpec.feature 'Users can answer repair questions' do
     choose_radio_button t('simple_form.options.start_form.answer.yes')
     click_continue
 
-    expect(page).to have_content 'Please call our repair centre'
+    expect(page).to have_content 'Emergency repairs'
   end
 
   scenario "Users can choose 'No' and is shown the next question" do

--- a/spec/features/users_can_diagnose_their_issue_spec.rb
+++ b/spec/features/users_can_diagnose_their_issue_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'Users can diagnose their issue' do
     choose_radio_button 'To an optional describe form'
     click_on 'Continue'
 
-    expect(page).to have_content 'Is there anything else we should know?'
+    expect(page).to have_content 'Please let us know any additional details'
 
     click_on 'Continue'
 

--- a/spec/features/users_can_diagnose_their_issue_spec.rb
+++ b/spec/features/users_can_diagnose_their_issue_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Users can diagnose their issue' do
     click_on 'Continue'
 
     expect(page.current_path).to eql '/pages/emergency_contact'
-    expect(page).to have_content 'Please call our repair centre'
+    expect(page).to have_content 'Emergency repairs'
   end
 
   scenario 'when the repair was diagnosed' do

--- a/spec/features/users_understand_purpose_of_service_spec.rb
+++ b/spec/features/users_understand_purpose_of_service_spec.rb
@@ -13,6 +13,6 @@ RSpec.feature 'Users understand the purpose of the service' do
 
     click_on 'Start'
 
-    expect(page).to have_content 'Do any of the following apply to you:'
+    expect(page).to have_content 'Do any of the following apply'
   end
 end


### PR DESCRIPTION
NB: The 'emergency filter' page has been changed from a simple Yes/No question to a radio button for each type of emergency. These redirect the user to information relevant to that particular emergency.

## Changes

Pages:

- Emergency contact page
- Service start page
- Emergency filter page (questions/start)
- Carbon monoxide alarm
- Gas
- Heating repairs
- Home adaptations
- Check fusebox
- Damp and mould
- Electrical hazard warning
- Replace lightbulb
- Smoke detector beeping
- Toilet unblocking

Describe repair forms:

- Generic response
- Kitchen cupboards
- Kitchen extractor fan
- Kitchen light fitting
- Kitchen light switch
- Communal boiler
- Basin leaking
- Bath leaking
- Toilet damaged
- Toilet leaking
- Boiler
- Broken tap
- Kitchen sink leaking
- Window damage
- Window not shutting
- External door stiff
- External door lock
- Internal door
- Sockets
