### PR TITLE
(145) Send room in description

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,8 +2,10 @@ class Question
   class InvalidAnswerError < StandardError; end
 
   attr_reader :title
+  attr_reader :id
 
-  def initialize(question_hash)
+  def initialize(id, question_hash)
+    @id = id
     @title = question_hash['question']
     @answers = question_hash['answers'] || []
     @route_helpers = Rails.application.routes.url_helpers

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,11 +1,11 @@
 class Question
   class InvalidAnswerError < StandardError; end
 
-  attr_reader :title
   attr_reader :id
+  attr_reader :title
 
-  def initialize(id, question_hash)
-    @id = id
+  def initialize(question_hash)
+    @id = question_hash['id']
     @title = question_hash['question']
     @answers = question_hash['answers'] || []
     @route_helpers = Rails.application.routes.url_helpers

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,7 +2,6 @@ class Question
   class InvalidAnswerError < StandardError; end
 
   attr_reader :title
-  attr_reader :next_question
 
   def initialize(question_hash)
     @title = question_hash['question']

--- a/app/models/question_set.rb
+++ b/app/models/question_set.rb
@@ -14,7 +14,8 @@ class QuestionSet
       raise UnknownQuestion, "Cannot find question with id '#{id}'"
     end
 
-    Question.new(id, @questions.fetch(id))
+    params = @questions.fetch(id).merge('id' => id)
+    Question.new(params)
   end
 
   class QuestionSetLoader

--- a/app/models/question_set.rb
+++ b/app/models/question_set.rb
@@ -2,8 +2,6 @@ class QuestionSet
   class Error < StandardError; end
   class UnknownQuestion < Error; end
   class BadlyFormattedYaml < Error; end
-  class MissingQuestions < Error; end
-  class MissingPartials < Error; end
 
   def initialize(filename = 'db/questions.yml', partial_checker:)
     yaml_data = File.read(Rails.root.join(filename))
@@ -16,7 +14,9 @@ class QuestionSet
 
     @questions = parsed_yaml.to_ruby
 
-    QuestionValidator.new(@questions, partial_checker).validate!
+    QuestionsValidator
+      .new(@questions, partial_checker: partial_checker)
+      .validate!
   end
 
   def find(id)
@@ -25,41 +25,5 @@ class QuestionSet
     end
 
     Question.new(@questions.fetch(id))
-  end
-
-  class QuestionValidator
-    def initialize(questions, partial_checker)
-      @questions = questions
-      @partial_checker = partial_checker
-    end
-
-    def validate!
-      validate_next
-      validate_desc
-    end
-
-    private
-
-    def validate_next
-      question_ids = @questions.keys.uniq
-      missing_question_ids = answer_values_for('next') - question_ids
-
-      raise MissingQuestions, missing_question_ids if missing_question_ids.any?
-    end
-
-    def validate_desc
-      missing_partials = answer_values_for('desc').reject do |partial_name|
-        @partial_checker.exists?(partial_name)
-      end
-
-      raise MissingPartials, missing_partials if missing_partials.any?
-    end
-
-    def answer_values_for(answer_type)
-      @questions.reduce([]) do |ids, (_k, v)|
-        answers = Array(v['answers'])
-        ids + answers.map { |a| a[answer_type] }.compact
-      end
-    end
   end
 end

--- a/app/models/question_set.rb
+++ b/app/models/question_set.rb
@@ -30,6 +30,7 @@ class QuestionSet
         .new(
           questions,
           partial_checker: @partial_checker,
+          mandatory_questions: ['location']
         ).validate!
 
       questions

--- a/app/models/question_set.rb
+++ b/app/models/question_set.rb
@@ -14,7 +14,7 @@ class QuestionSet
       raise UnknownQuestion, "Cannot find question with id '#{id}'"
     end
 
-    Question.new(@questions.fetch(id))
+    Question.new(id, @questions.fetch(id))
   end
 
   class QuestionSetLoader

--- a/app/models/question_set.rb
+++ b/app/models/question_set.rb
@@ -30,7 +30,7 @@ class QuestionSet
         .new(
           questions,
           partial_checker: @partial_checker,
-          mandatory_questions: ['location']
+          mandatory_questions: %w[location which_room]
         ).validate!
 
       questions

--- a/app/models/questions_validator.rb
+++ b/app/models/questions_validator.rb
@@ -1,22 +1,24 @@
 class QuestionsValidator
   class Error < StandardError; end
   class MissingQuestions < Error; end
+  class MissingMandatoryQuestions < Error; end
   class MissingPartials < Error; end
 
-  def initialize(questions, partial_checker:)
+  def initialize(questions, partial_checker:, mandatory_questions: [])
     @questions = questions
     @partial_checker = partial_checker
+    @mandatory_questions = mandatory_questions
   end
 
   def validate!
     validate_next
     validate_desc
+    validate_mandatory
   end
 
   private
 
   def validate_next
-    question_ids = @questions.keys.uniq
     missing_question_ids = answer_values_for('next') - question_ids
 
     raise MissingQuestions, missing_question_ids if missing_question_ids.any?
@@ -28,6 +30,17 @@ class QuestionsValidator
     end
 
     raise MissingPartials, missing_partials if missing_partials.any?
+  end
+
+  def validate_mandatory
+    missing_question_ids = @mandatory_questions - question_ids
+
+    return if missing_question_ids.empty?
+    raise MissingMandatoryQuestions, missing_question_ids
+  end
+
+  def question_ids
+    @questions.keys.uniq
   end
 
   def answer_values_for(answer_type)

--- a/app/models/questions_validator.rb
+++ b/app/models/questions_validator.rb
@@ -1,0 +1,39 @@
+class QuestionsValidator
+  class Error < StandardError; end
+  class MissingQuestions < Error; end
+  class MissingPartials < Error; end
+
+  def initialize(questions, partial_checker:)
+    @questions = questions
+    @partial_checker = partial_checker
+  end
+
+  def validate!
+    validate_next
+    validate_desc
+  end
+
+  private
+
+  def validate_next
+    question_ids = @questions.keys.uniq
+    missing_question_ids = answer_values_for('next') - question_ids
+
+    raise MissingQuestions, missing_question_ids if missing_question_ids.any?
+  end
+
+  def validate_desc
+    missing_partials = answer_values_for('desc').reject do |partial_name|
+      @partial_checker.exists?(partial_name)
+    end
+
+    raise MissingPartials, missing_partials if missing_partials.any?
+  end
+
+  def answer_values_for(answer_type)
+    @questions.reduce([]) do |ids, (_k, v)|
+      answers = Array(v['answers'])
+      ids + answers.map { |a| a[answer_type] }.compact
+    end
+  end
+end

--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -4,9 +4,15 @@ class RepairParams
   end
 
   def problem
-    return 'n/a' if description.blank?
-    return "#{description} (Room: #{room})" if room
-    description
+    if description.present? && room.present?
+      "#{description} (Room: #{room})"
+    elsif description.present?
+      description
+    elsif room.present?
+      "Room: #{room}"
+    else
+      'n/a'
+    end
   end
 
   def property_reference

--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -4,9 +4,9 @@ class RepairParams
   end
 
   def problem
-    @answers.fetch('describe_repair').fetch('description').tap do |problem|
-      return 'n/a' if problem.blank?
-    end
+    return 'n/a' if description.blank?
+    return "#{description} (Room: #{room})" if room
+    description
   end
 
   def property_reference
@@ -23,5 +23,15 @@ class RepairParams
 
   def diagnosed?
     sor_code.present?
+  end
+
+  private
+
+  def description
+    @answers.fetch('describe_repair').fetch('description')
+  end
+
+  def room
+    @answers.fetch('room', {})['room']
   end
 end

--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -18,7 +18,7 @@ class RepairParams
   end
 
   def sor_code
-    @answers.fetch('diagnosis', {})['sor_code']
+    @answers.dig('diagnosis', 'sor_code')
   end
 
   def diagnosed?
@@ -32,6 +32,6 @@ class RepairParams
   end
 
   def room
-    @answers.fetch('room', {})['room']
+    @answers.dig('room', 'room')
   end
 end

--- a/app/presenters/confirmation.rb
+++ b/app/presenters/confirmation.rb
@@ -43,7 +43,7 @@ class Confirmation
   end
 
   def room
-    @answers.fetch('room').fetch('room')
+    @answers.dig('room', 'room')
   end
 
   def description

--- a/app/presenters/confirmation.rb
+++ b/app/presenters/confirmation.rb
@@ -42,6 +42,10 @@ class Confirmation
     end
   end
 
+  def room
+    @answers.fetch('room').fetch('room')
+  end
+
   def description
     @answers.fetch('describe_repair').fetch('description')
   end

--- a/app/services/question_saver.rb
+++ b/app/services/question_saver.rb
@@ -16,6 +16,19 @@ class QuestionSaver
   private
 
   def persist_answers(form)
+    persist_room(form)
+    persist_sor_code(form)
+  end
+
+  def persist_room(form)
+    return unless @question.id == 'which_room'
+    @selected_answer_store.store_selected_answers(
+      :room,
+      room: form.answer
+    )
+  end
+
+  def persist_sor_code(form)
     sor_code = @question.answer_data(form.answer)['sor_code']
     return unless sor_code
     @selected_answer_store.store_selected_answers(

--- a/app/views/confirmations/show.html.haml
+++ b/app/views/confirmations/show.html.haml
@@ -19,7 +19,8 @@
     %h2 Summary
 
     %h3 Problem
-    %p= t('confirmation.summary.room', room: @confirmation.room)
+    - if @confirmation.room
+      %p= t('confirmation.summary.room', room: @confirmation.room)
     %p= t('confirmation.summary.description', description: @confirmation.description)
 
     %h3 Your details

--- a/app/views/confirmations/show.html.haml
+++ b/app/views/confirmations/show.html.haml
@@ -19,6 +19,7 @@
     %h2 Summary
 
     %h3 Problem
+    %p= t('confirmation.summary.room', room: @confirmation.room)
     %p= t('confirmation.summary.description', description: @confirmation.description)
 
     %h3 Your details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
   back_link: Back
   confirmation:
     summary:
+      room: 'Room: %{room}'
       description: 'Description: %{description}'
       name: 'Name: %{name}'
       phone: 'Phone number: %{phone}'

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: 'My sink is blocked',
+      problem: 'My sink is blocked (Room: Kitchen)',
       propertyRef: '00000503',
       repairOrders: [
         { jobCode: '0078965', propertyReference: '00000503' },
@@ -239,7 +239,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: 'My sink is blocked',
+      problem: 'My sink is blocked (Room: Other)',
       propertyRef: '00000503',
     )
   end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('location')
       .and_return(
         Question.new(
-          'location',
+          'id' => 'location',
           'question' => 'Where is the problem located?',
           'answers' => [
             { 'text' => 'Inside', 'next' => 'which_room' },
@@ -49,7 +49,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('which_room')
       .and_return(
         Question.new(
-          'which_room',
+          'id' => 'which_room',
           'question' => 'Which room?',
           'answers' => [
             { 'text' => 'Kitchen', 'next' => 'kitchen' },
@@ -63,7 +63,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('kitchen')
       .and_return(
         Question.new(
-          'kitchen',
+          'id' => 'kitchen',
           'question' => 'Is your tap broken?',
           'answers' => [
             { 'text' => 'Yes', 'sor_code' => '0078965' },
@@ -165,7 +165,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('location')
       .and_return(
         Question.new(
-          'location',
+          'id' => 'location',
           'question' => 'Where is the problem located?',
           'answers' => [
             { 'text' => 'Inside', 'next' => 'which_room' },
@@ -178,7 +178,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('which_room')
       .and_return(
         Question.new(
-          'which_room',
+          'id' => 'which_room',
           'question' => 'Which room?',
           'answers' => [
             { 'text' => 'Kitchen', 'next' => 'kitchen' },
@@ -277,7 +277,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('location')
       .and_return(
         Question.new(
-          'location',
+          'id' => 'location',
           'question' => 'Where is the problem located?',
           'answers' => [
             { 'text' => 'Inside', 'next' => 'which_room' },

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -243,4 +243,100 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       propertyRef: '00000503',
     )
   end
+
+  scenario 'when the issue was in a communal area' do
+    property = {
+      'property_reference' => '00000503',
+      'short_address' => 'Ross Court 23',
+      'postcode' => 'E5 8TE',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('properties?postcode=E5 8TE').and_return([property])
+    allow(fake_api).to receive(:get).with('properties/00000503').and_return(property)
+    allow(fake_api).to receive(:post)
+      .with('repairs', anything)
+      .and_return(
+        'requestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => 'The streetlamp is broken',
+        'propertyRef' => '00000503',
+      )
+    allow(fake_api).to receive(:get)
+      .with('repairs/00367923')
+      .and_return(
+        'requestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => 'The streetlamp is broken',
+        'propertyRef' => '00000503',
+      )
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    fake_question_set = instance_double(QuestionSet)
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('location')
+      .and_return(
+        Question.new(
+          'location',
+          'question' => 'Where is the problem located?',
+          'answers' => [
+            { 'text' => 'Inside', 'next' => 'which_room' },
+            { 'text' => 'Outside' },
+          ],
+        )
+      )
+    allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Outside'
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'The streetlamp is broken'
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E5 8TE'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Ross Court 23'
+    click_on 'Continue'
+
+    # Contact details - last page before confirmation:
+    fill_in 'Full name', with: 'John Evans'
+    fill_in 'Telephone number', with: '078 98765 432'
+    check 'morning (8am - 12pm)'
+    click_on 'Continue'
+
+    aggregate_failures do
+      within '#confirmation' do
+        expect(page).to have_content 'Your reference number is 00367923'
+        expect(page).to have_content 'between 8am and 12pm'
+      end
+
+      within '#summary' do
+        expect(page).to_not have_content t('confirmation.summary.room', room: '')
+        expect(page).to have_content t('confirmation.summary.description', description: 'The streetlamp is broken')
+
+        expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
+        expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
+        expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
+      end
+    end
+
+    expect(fake_api).to have_received(:post).with(
+      'repairs',
+      priority: 'N',
+      problem: 'The streetlamp is broken',
+      propertyRef: '00000503',
+    )
+  end
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -36,7 +36,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('location')
       .and_return(
         Question.new(
-          'question' => 'Where is the problem?',
+          'which_room',
+          'question' => 'Which room?',
           'answers' => [
             { 'text' => 'Kitchen', 'next' => 'kitchen' },
             { 'text' => 'Bathroom' },
@@ -49,6 +50,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('kitchen')
       .and_return(
         Question.new(
+          'kitchen',
           'question' => 'Is your tap broken?',
           'answers' => [
             { 'text' => 'Yes', 'sor_code' => '0078965' },

--- a/spec/features/users_can_diagnose_their_issue_spec.rb
+++ b/spec/features/users_can_diagnose_their_issue_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Users can diagnose their issue' do
       .with('first')
       .and_return(
         Question.new(
+          'fun',
           'question' => 'Are you having fun yet?',
           'answers' => [
             {
@@ -43,6 +44,7 @@ RSpec.feature 'Users can diagnose their issue' do
       .with('second')
       .and_return(
         Question.new(
+          'sure',
           'question' => 'Are you sure?',
           'answers' => [
             { 'text' => 'Absolutely!' },

--- a/spec/features/users_can_diagnose_their_issue_spec.rb
+++ b/spec/features/users_can_diagnose_their_issue_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Users can diagnose their issue' do
       .with('first')
       .and_return(
         Question.new(
-          'fun',
+          'id' => 'first',
           'question' => 'Are you having fun yet?',
           'answers' => [
             {
@@ -44,7 +44,7 @@ RSpec.feature 'Users can diagnose their issue' do
       .with('second')
       .and_return(
         Question.new(
-          'sure',
+          'id' => 'second',
           'question' => 'Are you sure?',
           'answers' => [
             { 'text' => 'Absolutely!' },

--- a/spec/fixtures/basic_question.yml
+++ b/spec/fixtures/basic_question.yml
@@ -1,4 +1,9 @@
 ---
+location:
+  question: Where is the problem located?
+  answers:
+    - text: Inside
+    - text: Outside
 example:
   question: Is this an example?
   answers:

--- a/spec/fixtures/basic_question.yml
+++ b/spec/fixtures/basic_question.yml
@@ -4,6 +4,12 @@ location:
   answers:
     - text: Inside
     - text: Outside
+which_room:
+  question: Which room?
+  answers:
+    - text: Kitchen
+    - text: Bathroom
+    - text: Other
 example:
   question: Is this an example?
   answers:

--- a/spec/models/question_set_spec.rb
+++ b/spec/models/question_set_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe QuestionSet do
     it 'throws an error if the YAML file links to a missing question' do
       expect do
         QuestionSet.new('spec/fixtures/missing_questions.yml', partial_checker: double)
-      end.to raise_error(QuestionSet::MissingQuestions)
+      end.to raise_error(QuestionsValidator::MissingQuestions)
     end
 
     it 'throws an error if the YAML file links to a missing description partial' do
       partial_checker = instance_double('DescriptionPartialChecker', exists?: false)
       expect do
         QuestionSet.new('spec/fixtures/missing_partials.yml', partial_checker: partial_checker)
-      end.to raise_error(QuestionSet::MissingPartials)
+      end.to raise_error(QuestionsValidator::MissingPartials)
     end
   end
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Question do
   describe '#title' do
     it 'is based on question data from a hash' do
       question = Question.new(
+        'presented',
         'question' => 'Is it presented?',
         'answers' => [
           { 'text' => 'Yeah' },
@@ -18,6 +19,7 @@ RSpec.describe Question do
   describe '#answers_for_collection' do
     it 'returns the answers in a format suitable for SimpleForm' do
       question = Question.new(
+        'animal',
         'question' => 'Favourite animal?',
         'answers' => [
           { 'text' => 'Antelope' },
@@ -32,6 +34,7 @@ RSpec.describe Question do
   describe '#answer_data' do
     it 'returns data for the given answer' do
       question = Question.new(
+        'animal',
         'question' => 'Favourite animal?',
         'answers' => [
           { 'text' => 'Antelope', 'next' => 'cooking_style' },
@@ -51,6 +54,7 @@ RSpec.describe Question do
     context 'when the answer is not valid' do
       it 'raises an error' do
         question = Question.new(
+          'animal',
           'question' => 'Favourite animal?',
           'answers' => [
             { 'text' => 'Antelope', 'next' => 'cooking_style' },
@@ -65,6 +69,7 @@ RSpec.describe Question do
   describe '#redirect_path_for_answer' do
     it 'is the path to the describe repair page by default' do
       question = Question.new(
+        'where',
         'question' => 'Where do you want to go?',
         'answers' => [
           {
@@ -79,6 +84,7 @@ RSpec.describe Question do
     context 'if answer has "next" key' do
       it 'returns the path to the next question' do
         question = Question.new(
+          'where',
           'question' => 'Where do you want to go?',
           'answers' => [
             {
@@ -95,6 +101,7 @@ RSpec.describe Question do
     context 'if answer has "page" key' do
       it 'returns the path to a static page' do
         question = Question.new(
+          'where',
           'question' => 'Where do you want to go?',
           'answers' => [
             {
@@ -111,6 +118,7 @@ RSpec.describe Question do
     context 'if answer has "desc" key' do
       it 'returns the path to a describe repair page' do
         question = Question.new(
+          'where',
           'question' => 'Where do you want to go?',
           'answers' => [
             {

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,10 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Question do
+  describe '#id' do
+    it 'is based on question data from a hash' do
+      question = Question.new(
+        'id' => 'presented',
+        'question' => 'Is it presented?',
+        'answers' => [
+          { 'text' => 'Yeah' },
+          { 'text' => 'Nope' },
+        ],
+      )
+
+      expect(question.id).to eql 'presented'
+    end
+  end
+
   describe '#title' do
     it 'is based on question data from a hash' do
       question = Question.new(
-        'presented',
+        'id' => 'presented',
         'question' => 'Is it presented?',
         'answers' => [
           { 'text' => 'Yeah' },
@@ -19,7 +34,7 @@ RSpec.describe Question do
   describe '#answers_for_collection' do
     it 'returns the answers in a format suitable for SimpleForm' do
       question = Question.new(
-        'animal',
+        'id' => 'animal',
         'question' => 'Favourite animal?',
         'answers' => [
           { 'text' => 'Antelope' },
@@ -34,7 +49,7 @@ RSpec.describe Question do
   describe '#answer_data' do
     it 'returns data for the given answer' do
       question = Question.new(
-        'animal',
+        'id' => 'animal',
         'question' => 'Favourite animal?',
         'answers' => [
           { 'text' => 'Antelope', 'next' => 'cooking_style' },
@@ -54,7 +69,7 @@ RSpec.describe Question do
     context 'when the answer is not valid' do
       it 'raises an error' do
         question = Question.new(
-          'animal',
+          'id' => 'animal',
           'question' => 'Favourite animal?',
           'answers' => [
             { 'text' => 'Antelope', 'next' => 'cooking_style' },
@@ -69,7 +84,7 @@ RSpec.describe Question do
   describe '#redirect_path_for_answer' do
     it 'is the path to the describe repair page by default' do
       question = Question.new(
-        'where',
+        'id' => 'where',
         'question' => 'Where do you want to go?',
         'answers' => [
           {
@@ -84,7 +99,7 @@ RSpec.describe Question do
     context 'if answer has "next" key' do
       it 'returns the path to the next question' do
         question = Question.new(
-          'where',
+          'id' => 'where',
           'question' => 'Where do you want to go?',
           'answers' => [
             {
@@ -101,7 +116,7 @@ RSpec.describe Question do
     context 'if answer has "page" key' do
       it 'returns the path to a static page' do
         question = Question.new(
-          'where',
+          'id' => 'where',
           'question' => 'Where do you want to go?',
           'answers' => [
             {
@@ -118,7 +133,7 @@ RSpec.describe Question do
     context 'if answer has "desc" key' do
       it 'returns the path to a describe repair page' do
         question = Question.new(
-          'where',
+          'id' => 'where',
           'question' => 'Where do you want to go?',
           'answers' => [
             {

--- a/spec/models/questions_validator_spec.rb
+++ b/spec/models/questions_validator_spec.rb
@@ -54,4 +54,29 @@ RSpec.describe QuestionsValidator do
         .to_not raise_error
     end
   end
+
+  context 'when questions which must be included are specified' do
+    it 'returns successfully if these questions are included' do
+      questions = {
+        'location' => {
+          'question' => 'Where is the problem located?',
+          'answers' => [
+            {
+              'text' => 'Somewhere else',
+            },
+          ],
+        },
+      }
+      partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
+      expect { QuestionsValidator.new(questions, partial_checker: partial_checker, mandatory_questions: ['location']).validate! }
+        .to_not raise_error
+    end
+
+    it 'throws an error if these questions are not included' do
+      questions = {}
+      partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
+      expect { QuestionsValidator.new(questions, partial_checker: partial_checker, mandatory_questions: ['which_room']).validate! }
+        .to raise_error(QuestionsValidator::MissingMandatoryQuestions)
+    end
+  end
 end

--- a/spec/models/questions_validator_spec.rb
+++ b/spec/models/questions_validator_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'app/models/questions_validator'
+
+RSpec.describe QuestionsValidator do
+  describe '#validate!' do
+    it 'throws an error if there is a link to a missing question' do
+      questions = {
+        'location' => {
+          'question' => 'Where is the problem located?',
+          'answers' => [
+            {
+              'text' => 'In a communal area',
+              'next' => 'missing_question',
+            },
+          ],
+        },
+      }
+      partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
+      expect { QuestionsValidator.new(questions, partial_checker: partial_checker).validate! }
+        .to raise_error(QuestionsValidator::MissingQuestions)
+    end
+
+    it 'throws an error if there is a link to a missing description partial' do
+      questions = {
+        'location' => {
+          'question' => 'Where is the problem located?',
+          'answers' => [
+            {
+              'text' => 'Somewhere else',
+              'desc' => 'a_partial_which_does_not_exist',
+            },
+          ],
+        },
+      }
+      partial_checker = instance_double('DescriptionPartialChecker', exists?: false)
+      expect { QuestionsValidator.new(questions, partial_checker: partial_checker).validate! }
+        .to raise_error(QuestionsValidator::MissingPartials)
+    end
+
+    it 'returns successfully if there is a link to a description partial which exists' do
+      questions = {
+        'location' => {
+          'question' => 'Where is the problem located?',
+          'answers' => [
+            {
+              'text' => 'Somewhere else',
+              'desc' => 'a_partial_which_exists',
+            },
+          ],
+        },
+      }
+      partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
+      expect { QuestionsValidator.new(questions, partial_checker: partial_checker).validate! }
+        .to_not raise_error
+    end
+  end
+end

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe RepairParams do
         }
         expect(RepairParams.new(answers).problem).to eq 'My bath is broken (Room: Bathroom)'
       end
+
+      it 'describes the room if there was no description' do
+        answers = {
+          'describe_repair' => {
+            'description' => '',
+          },
+          'room' => {
+            'room' => 'Bathroom',
+          },
+        }
+        expect(RepairParams.new(answers).problem).to eq 'Room: Bathroom'
+      end
     end
   end
 

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe RepairParams do
         expect(RepairParams.new(answers).problem).to eq 'n/a'
       end
     end
+
+    context 'if a room was specified' do
+      it 'includes the room in the description' do
+        answers = {
+          'describe_repair' => {
+            'description' => 'My bath is broken',
+          },
+          'room' => {
+            'room' => 'Bathroom',
+          },
+        }
+        expect(RepairParams.new(answers).problem).to eq 'My bath is broken (Room: Bathroom)'
+      end
+    end
   end
 
   describe '#property_reference' do

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -108,6 +108,19 @@ RSpec.describe Confirmation do
     end
   end
 
+  describe 'room' do
+    it 'Returns the stored room' do
+      fake_answers = {
+        'room' => {
+          'room' => 'Kitchen',
+        },
+      }
+
+      expect(Confirmation.new(request_reference: '00000000', answers: fake_answers, api: double).room)
+        .to eq 'Kitchen'
+    end
+  end
+
   describe 'description' do
     it 'Returns the stored description' do
       fake_answers = {

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe CreateRepair do
         'describe_repair' => {
           'description' => 'My bath is broken',
         },
+        'room' => {
+          'room' => 'Bathroom',
+        },
       }
 
       service = CreateRepair.new(api: fake_api)
@@ -26,7 +29,7 @@ RSpec.describe CreateRepair do
       expect(fake_api).to have_received(:create_repair)
         .with(
           priority: 'N',
-          problem: 'My bath is broken',
+          problem: 'My bath is broken (Room: Bathroom)',
           propertyRef: '00034713',
         )
     end

--- a/spec/services/question_saver_spec.rb
+++ b/spec/services/question_saver_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe QuestionSaver do
   describe '.save' do
     context 'when there is an SOR code on the question' do
       it 'persists form data to the selected answer store' do
-        fake_question = instance_double('Question')
+        fake_question = instance_double('Question', id: 'start')
         allow(fake_question).to receive(:answer_data).with('Yes').and_return('sor_code' => '012345')
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)
@@ -25,7 +25,7 @@ RSpec.describe QuestionSaver do
       end
 
       it 'returns true' do
-        fake_question = instance_double('Question')
+        fake_question = instance_double('Question', id: 'start')
         allow(fake_question).to receive(:answer_data).with('Yes').and_return('sor_code' => '012345')
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)
@@ -38,9 +38,31 @@ RSpec.describe QuestionSaver do
       end
     end
 
+    context 'when there is a room on the question' do
+      it 'persists form data to the selected answer store' do
+        fake_question = instance_double('Question', id: 'which_room')
+        allow(fake_question).to receive(:answer_data).with('Kitchen').and_return({})
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('QuestionForm',
+                                    valid?: true,
+                                    answer: 'Kitchen')
+
+        saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
+        saver.save(fake_form)
+
+        expect(fake_answer_store)
+          .to have_received(:store_selected_answers)
+          .with(
+            :room,
+            room: 'Kitchen',
+          )
+      end
+    end
+
     context 'when there is no SOR code on the question' do
       it "doesn't change the selected answer store" do
-        fake_question = instance_double('Question')
+        fake_question = instance_double('Question', id: 'start')
         allow(fake_question).to receive(:answer_data).with('Yes').and_return('next' => 'suggested_countermeasures')
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)
@@ -57,7 +79,7 @@ RSpec.describe QuestionSaver do
       it 'returns true' do
         # ...because even though we're not doing anything, it's not a failure
         # and the caller shouldn't have to care
-        fake_question = instance_double('Question')
+        fake_question = instance_double('Question', id: 'start')
         allow(fake_question).to receive(:answer_data).with('Yes').and_return('next' => 'suggested_countermeasures')
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -8,7 +8,7 @@ module CapybaraHelpers
     allow(fake_question_set)
       .to receive(:find)
       .with(id)
-      .and_return(Question.new(id, 'question' => question, 'answers' => answers))
+      .and_return(Question.new('id' => id, 'question' => question, 'answers' => answers))
     allow(QuestionSet).to receive(:new).and_return(fake_question_set)
   end
 end

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -8,7 +8,7 @@ module CapybaraHelpers
     allow(fake_question_set)
       .to receive(:find)
       .with(id)
-      .and_return(Question.new('question' => question, 'answers' => answers))
+      .and_return(Question.new(id, 'question' => question, 'answers' => answers))
     allow(QuestionSet).to receive(:new).and_return(fake_question_set)
   end
 end


### PR DESCRIPTION
- Introduce 'mandatory' questions
- We talked about sending it as a special field, but this doesn't seem to have been locked in in the API standards, so send it in the description instead