### PR TITLE
(176) Session is reset before reporting a new repair

### DIFF
--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -1,6 +1,8 @@
 module Questions
   class StartController < ApplicationController
     def index
+      reset_session
+
       @form = StartForm.new
     end
 

--- a/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
+++ b/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
@@ -90,6 +90,22 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
       )
     allow(QuestionSet).to receive(:new).and_return(fake_question_set)
 
+    # FIRST VISIT ========================
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Kitchen'
+    click_on 'Continue'
+
+    choose_radio_button 'Yes' # Gets a SOR code
+    click_on 'Continue'
+
+    # SECOND VISIT ========================
     visit '/'
     click_on 'Start'
 
@@ -116,51 +132,12 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
     choose_radio_button 'Ross Court 42'
     click_on 'Continue'
 
-    # Contact details - last page before confirmation:
+    # Contact details
     fill_in 'Full name', with: 'Jane Evans'
     fill_in 'Telephone number', with: '07900 424242'
-    check 'morning (8am to midday)'
+    choose_radio_button 'morning (8am to midday)'
     click_on 'Continue'
 
-    # Confirmation page
-    expect(page).to have_content('We will call you within one working day, between 8am and midday')
-
-    visit '/'
-    click_on 'Start'
-
-    # Emergency page:
-    choose_radio_button 'No'
-    click_on 'Continue'
-
-    # Fake decision tree
-    choose_radio_button 'Kitchen'
-    click_on 'Continue'
-
-    choose_radio_button 'Yes' # Gets a SOR code
-    click_on 'Continue'
-
-    # Describe problem:
-    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
-    click_on 'Continue'
-
-    # Address search:
-    fill_in 'Postcode', with: 'E5 8TE'
-    click_on 'Find my address'
-
-    # Address selection:
-    choose_radio_button 'Ross Court 42'
-    click_on 'Continue'
-
-    # Contact details - last page before confirmation:
-    fill_in 'Full name', with: 'Jane Evans'
-    fill_in 'Telephone number', with: '07900 424242'
-    click_on 'Continue'
-
-    # Book appointment
-    choose_radio_button 'Monday 10am to midday (27th November)'
-    click_on 'Continue'
-
-    # Confirmation page
-    expect(page).to have_content('Your appointment has been booked for Monday 27th November between 10am and midday.')
+    expect(page).to have_content 'We will call you within one working day, between 8am and midday'
   end
 end

--- a/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
+++ b/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+RSpec.feature 'Users can report a repair without previous answers affecting the result' do
+  scenario 'when the user chose a callback time last time and now has to book an appointment' do
+    property = {
+      'propertyReference' => '00000512',
+      'address' => 'Ross Court 42',
+      'postcode' => 'E5 8TE',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get)
+      .with('v1/properties?postcode=E5 8TE')
+      .and_return('results' => [property])
+    allow(fake_api).to receive(:get)
+      .with('v1/properties/00000512')
+      .and_return(property)
+    allow(fake_api).to receive(:post)
+      .with('v1/repairs', anything)
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'priority' => 'N',
+        'problemDescription' => 'My sink is blocked',
+        'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ],
+      )
+    allow(fake_api).to receive(:get)
+      .with('v1/repairs/00367923')
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'orderReference' => '09124578',
+        'priority' => 'N',
+        'problemDescription' => 'My sink is blocked',
+        'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ],
+      )
+    allow(fake_api).to receive(:get)
+      .with('v1/work_orders/09124578/available_appointments')
+      .and_return(
+        'results' => [
+          {
+            'beginDate' => '2017-11-27T10:00:00Z',
+            'endDate' => '2017-11-27T12:00:00Z',
+            'bestSlot' => true,
+          },
+        ]
+      )
+    allow(fake_api).to receive(:post)
+      .with('v1/work_orders/09124578/appointments', anything)
+      .and_return(
+        'beginDate' => '2017-11-27T10:00:00Z',
+        'endDate' => '2017-11-27T12:00:00Z'
+      )
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    fake_question_set = instance_double(QuestionSet)
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('location')
+      .and_return(
+        Question.new(
+          'question' => 'Where is the problem?',
+          'answers' => [
+            { 'text' => 'Kitchen', 'next' => 'kitchen' },
+            { 'text' => 'Bathroom' },
+            { 'text' => 'Other' },
+          ],
+        )
+      )
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('kitchen')
+      .and_return(
+        Question.new(
+          'question' => 'Is your tap broken?',
+          'answers' => [
+            { 'text' => 'Yes', 'sor_code' => '0078965' },
+            { 'text' => 'No' },
+          ],
+        )
+      )
+    allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Kitchen'
+    click_on 'Continue'
+
+    choose_radio_button 'No' # Doesn't get a SOR code
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E5 8TE'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Ross Court 42'
+    click_on 'Continue'
+
+    # Contact details - last page before confirmation:
+    fill_in 'Full name', with: 'Jane Evans'
+    fill_in 'Telephone number', with: '07900 424242'
+    check 'morning (8am to midday)'
+    click_on 'Continue'
+
+    # Confirmation page
+    expect(page).to have_content('We will call you within one working day, between 8am and midday')
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Kitchen'
+    click_on 'Continue'
+
+    choose_radio_button 'Yes' # Gets a SOR code
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E5 8TE'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Ross Court 42'
+    click_on 'Continue'
+
+    # Contact details - last page before confirmation:
+    fill_in 'Full name', with: 'Jane Evans'
+    fill_in 'Telephone number', with: '07900 424242'
+    click_on 'Continue'
+
+    # Book appointment
+    choose_radio_button 'Monday 10am to midday (27th November)'
+    click_on 'Continue'
+
+    # Confirmation page
+    expect(page).to have_content('Your appointment has been booked for Monday 27th November between 10am and midday.')
+  end
+end


### PR DESCRIPTION
Reset the session when starting to work through the service a second
time. This ensures that users don't see previous answers in the forms
and also prevents a situation where the repair has both a `sor_code` and
a `callback_time`, which should be mutally exclusive.

NB: This users a controller spec rather that a feature spec, because the
contents of the encrypted session is not available from Capybara, so
there is no way of knowing if it was reset correctly.