### PR TITLE
(207) Tidy up confirmation page

### DIFF
--- a/app/presenters/confirmation.rb
+++ b/app/presenters/confirmation.rb
@@ -43,14 +43,6 @@ class Confirmation
     end
   end
 
-  def room
-    @answers.dig('room', 'room')
-  end
-
-  def description
-    @answers.fetch('describe_repair').fetch('description')
-  end
-
   private
 
   def contact_details_answer

--- a/app/views/confirmations/show.html.haml
+++ b/app/views/confirmations/show.html.haml
@@ -16,13 +16,6 @@
 
 .grid-row
   %section#summary.column-two-thirds
-    %h2 Summary
-
-    %h3 Problem
-    - if @confirmation.room
-      %p= t('confirmation.summary.room', room: @confirmation.room)
-    %p= t('confirmation.summary.description', description: @confirmation.description)
-
     %h3 Your details
     %p= t('confirmation.summary.name', name: @confirmation.full_name)
     %p= t('confirmation.summary.phone', phone: @confirmation.telephone_number)

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -147,9 +147,6 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       end
 
       within '#summary' do
-        expect(page).to have_content t('confirmation.summary.room', room: 'Kitchen')
-        expect(page).to have_content t('confirmation.summary.description', description: 'My sink is blocked')
-
         expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
         expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
         expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
@@ -273,9 +270,6 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       end
 
       within '#summary' do
-        expect(page).to have_content t('confirmation.summary.room', room: 'Other')
-        expect(page).to have_content t('confirmation.summary.description', description: 'My sink is blocked')
-
         expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
         expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
         expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
@@ -373,9 +367,6 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       end
 
       within '#summary' do
-        expect(page).to_not have_content t('confirmation.summary.room', room: '')
-        expect(page).to have_content t('confirmation.summary.description', description: 'The streetlamp is broken')
-
         expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
         expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
         expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -113,30 +113,4 @@ RSpec.describe Confirmation do
       end
     end
   end
-
-  describe 'room' do
-    it 'Returns the stored room' do
-      fake_answers = {
-        'room' => {
-          'room' => 'Kitchen',
-        },
-      }
-
-      expect(Confirmation.new(request_reference: '00000000', answers: fake_answers, api: double).room)
-        .to eq 'Kitchen'
-    end
-  end
-
-  describe 'description' do
-    it 'Returns the stored description' do
-      fake_answers = {
-        'describe_repair' => {
-          'description' => 'My bath is broken',
-        },
-      }
-
-      expect(Confirmation.new(request_reference: '00000000', answers: fake_answers, api: double).description)
-        .to eq 'My bath is broken'
-    end
-  end
 end


### PR DESCRIPTION
Remove 'Summary' and 'Problem' headings, as well as the description of
the problem the user entered.