### PR TITLE
(136) Hide service from web crawlers

### DIFF
--- a/app/assets/javascripts/back_link.js
+++ b/app/assets/javascripts/back_link.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
   function backLink(text) {
-    var backLink = $("<a class='link-back' href='#'></a>");
+    var backLink = $("<a class='link-back' href='#' rel='nofollow'></a>");
     backLink.text(text);
     backLink.click(function(){
       parent.history.back();

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+# Users should only find the service through the main Hackney web site
+User-agent: *
+Disallow: /


### PR DESCRIPTION
We want users of the service to find us via the main hackney.gov.uk web site, so block web crawlers from indexing the site.