### PR TITLE
(202) Properties endpoint fixes

### DIFF
--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -16,7 +16,7 @@ class RepairParams
   end
 
   def property_reference
-    @answers.fetch('address').fetch('property_reference')
+    @answers.fetch('address').fetch('propertyReference')
   end
 
   def priority

--- a/app/presenters/confirmation.rb
+++ b/app/presenters/confirmation.rb
@@ -18,7 +18,7 @@ class Confirmation
   def address
     address_answer = @answers.fetch('address')
     [
-      address_answer.fetch('short_address'),
+      address_answer.fetch('address'),
       address_answer.fetch('postcode'),
     ].join(', ')
   end

--- a/app/queries/address_finder.rb
+++ b/app/queries/address_finder.rb
@@ -8,10 +8,10 @@ class AddressFinder
     properties.map do |property|
       Property.new(
         property['property_reference'],
-        property['short_address']
+        property['address']
       )
     end
   end
 
-  Property = Struct.new(:property_reference, :short_address)
+  Property = Struct.new(:property_reference, :address)
 end

--- a/app/queries/address_finder.rb
+++ b/app/queries/address_finder.rb
@@ -8,10 +8,11 @@ class AddressFinder
     properties.map do |property|
       Property.new(
         property['property_reference'],
-        property['address']
+        property['address'],
+        property['postcode'],
       )
     end
   end
 
-  Property = Struct.new(:property_reference, :address)
+  Property = Struct.new(:property_reference, :address, :postcode)
 end

--- a/app/queries/address_finder.rb
+++ b/app/queries/address_finder.rb
@@ -7,7 +7,7 @@ class AddressFinder
     properties = @api.list_properties(postcode: form.data[:postcode])
     properties.map do |property|
       Property.new(
-        property['property_reference'],
+        property['propertyReference'],
         property['address'],
         property['postcode'],
       )

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -4,11 +4,11 @@ class HackneyApi
   end
 
   def list_properties(postcode:)
-    @json_api.get('properties?postcode=' + postcode)
+    @json_api.get('v1/properties?postcode=' + postcode)
   end
 
   def get_property(property_reference:)
-    @json_api.get('properties/' + property_reference)
+    @json_api.get('v1/properties/' + property_reference)
   end
 
   def create_repair(repair_params)

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -4,7 +4,8 @@ class HackneyApi
   end
 
   def list_properties(postcode:)
-    @json_api.get('v1/properties?postcode=' + postcode)
+    response = @json_api.get('v1/properties?postcode=' + postcode)
+    response.fetch('results')
   end
 
   def get_property(property_reference:)

--- a/app/services/create_repair.rb
+++ b/app/services/create_repair.rb
@@ -15,7 +15,7 @@ class CreateRepair
     {
       priority: params.priority,
       problem: params.problem,
-      propertyRef: params.property_reference,
+      propertyReference: params.property_reference,
     }.tap do |hash|
       hash[:repairOrders] = create_work_order_params(params) if params.sor_code
     end
@@ -25,7 +25,6 @@ class CreateRepair
     [
       {
         jobCode: params.sor_code,
-        propertyReference: params.property_reference,
       },
     ]
   end

--- a/app/views/address_searches/create.html.haml
+++ b/app/views/address_searches/create.html.haml
@@ -20,7 +20,7 @@
           = f.input :property_reference,
             as: :radio_buttons,
             collection: @address_search.results,
-            label_method: :short_address,
+            label_method: :address,
             value_method: :property_reference,
             required: true
 

--- a/app/views/contact_details_with_callback/index.html.haml
+++ b/app/views/contact_details_with_callback/index.html.haml
@@ -14,4 +14,4 @@
       = f.button :submit
 
 %aside#progress
-  = @selected_answers['short_address']
+  = @selected_answers['address']

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -22,8 +22,8 @@ RSpec.feature 'Resident can locate a problem' do
     matching_properties = [other_property, tenant_property]
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return(matching_properties)
-    allow(fake_api).to receive(:get).with('properties/abc123').and_return(tenant_property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return(matching_properties)
+    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(tenant_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -46,7 +46,7 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'when the address search returned no results' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -83,8 +83,8 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'changing the postcode after searching' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=N1 6AA').and_return([])
-    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6AA').and_return([])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -110,7 +110,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([matching_property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([matching_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -132,7 +132,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=N1 6NU').and_return([other_property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([other_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -10,11 +10,11 @@ RSpec.feature 'Resident can locate a problem' do
   scenario 'when they are a Hackney Council Tenant' do
     tenant_property = {
       'property_reference' => 'abc123',
-      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
     }
     other_property = {
       'property_reference' => 'def456',
-      'short_address' => 'Flat 7, 12 Hoxton Square, N1 6NU',
+      'address' => 'Flat 7, 12 Hoxton Square, N1 6NU',
     }
 
     matching_properties = [other_property, tenant_property]
@@ -103,7 +103,7 @@ RSpec.feature 'Resident can locate a problem' do
   scenario 'performing a search and not selecting an address' do
     matching_property = {
       'property_reference' => 'abc123',
-      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
     }
 
     fake_api = instance_double(JsonApi)
@@ -124,7 +124,7 @@ RSpec.feature 'Resident can locate a problem' do
   scenario "user's address isn't listed" do
     other_property = {
       'property_reference' => 'abc123',
-      'short_address' => '99 Abersham Road',
+      'address' => '99 Abersham Road',
     }
 
     fake_api = instance_double(JsonApi)

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -9,12 +9,12 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'when they are a Hackney Council Tenant' do
     tenant_property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
     other_property = {
-      'property_reference' => 'def456',
+      'propertyReference' => 'def456',
       'address' => 'Flat 7, 12 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
@@ -104,7 +104,7 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'performing a search and not selecting an address' do
     matching_property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
@@ -126,7 +126,7 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario "user's address isn't listed" do
     other_property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => '99 Abersham Road',
       'postcode' => 'N1 6NU',
     }

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -11,10 +11,12 @@ RSpec.feature 'Resident can locate a problem' do
     tenant_property = {
       'property_reference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
     other_property = {
       'property_reference' => 'def456',
       'address' => 'Flat 7, 12 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
 
     matching_properties = [other_property, tenant_property]
@@ -104,6 +106,7 @@ RSpec.feature 'Resident can locate a problem' do
     matching_property = {
       'property_reference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
 
     fake_api = instance_double(JsonApi)
@@ -125,6 +128,7 @@ RSpec.feature 'Resident can locate a problem' do
     other_property = {
       'property_reference' => 'abc123',
       'address' => '99 Abersham Road',
+      'postcode' => 'N1 6NU',
     }
 
     fake_api = instance_double(JsonApi)

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Resident can locate a problem' do
     matching_properties = [other_property, tenant_property]
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return(matching_properties)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => matching_properties)
     allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(tenant_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -46,7 +46,7 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'when the address search returned no results' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -83,8 +83,8 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'changing the postcode after searching' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6AA').and_return([])
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6AA').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -110,7 +110,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([matching_property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [matching_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -132,7 +132,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return([other_property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [other_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -10,12 +10,12 @@ RSpec.feature 'Resident can locate a problem' do
   scenario 'when they are a Hackney Council Tenant' do
     tenant_property = {
       'property_reference' => 'abc123',
-      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
     other_property = {
       'property_reference' => 'def456',
-      'address' => 'Flat 7, 12 Hoxton Square, N1 6NU',
+      'address' => 'Flat 7, 12 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
 
@@ -32,7 +32,7 @@ RSpec.feature 'Resident can locate a problem' do
     click_button t('helpers.submit.address_search.create')
 
     within '#address-search-results' do
-      choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
+      choose_radio_button 'Flat 1, 8 Hoxton Square'
     end
 
     click_button t('helpers.submit.create')
@@ -40,7 +40,7 @@ RSpec.feature 'Resident can locate a problem' do
     expect(page).to have_content t('contact-details.title')
 
     within '#progress' do
-      expect(page).to have_content 'Flat 1, 8 Hoxton Square, N1 6NU'
+      expect(page).to have_content 'Flat 1, 8 Hoxton Square'
     end
   end
 
@@ -105,7 +105,7 @@ RSpec.feature 'Resident can locate a problem' do
   scenario 'performing a search and not selecting an address' do
     matching_property = {
       'property_reference' => 'abc123',
-      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
 

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the repair was diagnosed' do
     property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
@@ -58,7 +58,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'when the repair could not be diagnosed' do
     property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
@@ -146,7 +146,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'when the contact details values were invalid' do
     property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
@@ -193,7 +193,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'when the contact details with callback values were invalid' do
     property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
@@ -253,7 +253,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'going back from the My address is not here exit page' do
     property = {
-      'property_reference' => 'abc123',
+      'propertyReference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the repair was diagnosed' do
     property = {
       'property_reference' => 'abc123',
-      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -58,7 +58,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the repair could not be diagnosed' do
     property = {
       'property_reference' => 'abc123',
-      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -145,7 +145,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the contact details values were invalid' do
     property = {
       'property_reference' => 'abc123',
-      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -191,7 +191,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the contact details with callback values were invalid' do
     property = {
       'property_reference' => 'abc123',
-      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -250,7 +250,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'going back from the My address is not here exit page' do
     property = {
       'property_reference' => 'abc123',
-      'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the repair was diagnosed' do
     property = {
       'property_reference' => 'abc123',
-      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
@@ -33,7 +33,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Find my address'
 
     # Address selection:
-    choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
+    choose_radio_button 'Flat 1, 8 Hoxton Square'
     click_on 'Continue'
 
     # Contact details
@@ -59,7 +59,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the repair could not be diagnosed' do
     property = {
       'property_reference' => 'abc123',
-      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
@@ -89,7 +89,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Find my address'
 
     # Address selection:
-    choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
+    choose_radio_button 'Flat 1, 8 Hoxton Square'
     click_on 'Continue'
 
     # Contact details with callback - last page before confirmation:
@@ -147,7 +147,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the contact details values were invalid' do
     property = {
       'property_reference' => 'abc123',
-      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
@@ -176,7 +176,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Find my address'
 
     # Address selection:
-    choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
+    choose_radio_button 'Flat 1, 8 Hoxton Square'
     click_on 'Continue'
 
     # Contact details - submit an empty form
@@ -194,7 +194,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'when the contact details with callback values were invalid' do
     property = {
       'property_reference' => 'abc123',
-      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
@@ -224,7 +224,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Find my address'
 
     # Address selection:
-    choose_radio_button 'Flat 1, 8 Hoxton Square, N1 6NU'
+    choose_radio_button 'Flat 1, 8 Hoxton Square'
     click_on 'Continue'
 
     # Contact details - submit an empty form
@@ -254,7 +254,7 @@ RSpec.feature 'Resident can navigate back', js: true do
   scenario 'going back from the My address is not here exit page' do
     property = {
       'property_reference' => 'abc123',
-      'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'address' => 'Flat 1, 8 Hoxton Square',
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
-    allow(fake_api).to receive(:get).with('properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(question: 'What is the problem?', answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])
@@ -63,8 +63,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
-    allow(fake_api).to receive(:get).with('properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(question: 'What is the problem?', answers: [{ 'text' => 'skip' }])
@@ -151,8 +151,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
-    allow(fake_api).to receive(:get).with('properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])
@@ -198,8 +198,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
-    allow(fake_api).to receive(:get).with('properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -258,7 +258,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -292,7 +292,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'going back from the address selection page' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     property = {
       'property_reference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -59,6 +60,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     property = {
       'property_reference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -146,6 +148,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     property = {
       'property_reference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -192,6 +195,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     property = {
       'property_reference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])
@@ -251,6 +255,7 @@ RSpec.feature 'Resident can navigate back', js: true do
     property = {
       'property_reference' => 'abc123',
       'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+      'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('properties?postcode=E8 5TQ').and_return([property])

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -63,7 +63,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -151,7 +151,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -198,7 +198,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -258,7 +258,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -292,7 +292,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'going back from the address selection page' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return([])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
@@ -170,7 +170,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
@@ -282,7 +282,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
       .with('repairs', anything)

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
   scenario 'when the issue was diagnosed and an appointment was booked' do
     property = {
       'property_reference' => '00000503',
-      'short_address' => 'Ross Court 23',
+      'address' => 'Ross Court 23',
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
@@ -166,7 +166,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
   scenario 'when the issue could not be completely diagnosed (and a callback is required)' do
     property = {
       'property_reference' => '00000503',
-      'short_address' => 'Ross Court 23',
+      'address' => 'Ross Court 23',
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
@@ -278,7 +278,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
   scenario 'when the issue was in a communal area' do
     property = {
       'property_reference' => '00000503',
-      'short_address' => 'Ross Court 23',
+      'address' => 'Ross Court 23',
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Resident can see a confirmation of their repair request' do
   scenario 'when the issue was diagnosed and an appointment was booked' do
     property = {
-      'property_reference' => '00000503',
+      'propertyReference' => '00000503',
       'address' => 'Ross Court 23',
       'postcode' => 'E5 8TE',
     }
@@ -17,7 +17,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'orderReference' => '09124578',
         'priority' => 'N',
         'problem' => 'My sink is blocked',
-        'propertyRef' => '00000503',
+        'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
       .with('repairs/00367923')
@@ -26,7 +26,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'orderReference' => '09124578',
         'priority' => 'N',
         'problem' => 'My sink is blocked',
-        'propertyRef' => '00000503',
+        'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
       .with('work_orders/09124578/appointments')
@@ -150,9 +150,9 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'repairs',
       priority: 'N',
       problem: 'My sink is blocked (Room: Kitchen)',
-      propertyRef: '00000503',
+      propertyReference: '00000503',
       repairOrders: [
-        { jobCode: '0078965', propertyReference: '00000503' },
+        { jobCode: '0078965' },
       ]
     )
 
@@ -165,7 +165,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
 
   scenario 'when the issue could not be completely diagnosed (and a callback is required)' do
     property = {
-      'property_reference' => '00000503',
+      'propertyReference' => '00000503',
       'address' => 'Ross Court 23',
       'postcode' => 'E5 8TE',
     }
@@ -178,7 +178,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'requestReference' => '00367923',
         'priority' => 'N',
         'problem' => 'My sink is blocked',
-        'propertyRef' => '00000503',
+        'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
       .with('repairs/00367923')
@@ -186,7 +186,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'requestReference' => '00367923',
         'priority' => 'N',
         'problem' => 'My sink is blocked',
-        'propertyRef' => '00000503',
+        'propertyReference' => '00000503',
       )
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -271,13 +271,13 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'repairs',
       priority: 'N',
       problem: 'My sink is blocked (Room: Other)',
-      propertyRef: '00000503',
+      propertyReference: '00000503',
     )
   end
 
   scenario 'when the issue was in a communal area' do
     property = {
-      'property_reference' => '00000503',
+      'propertyReference' => '00000503',
       'address' => 'Ross Court 23',
       'postcode' => 'E5 8TE',
     }
@@ -290,7 +290,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'requestReference' => '00367923',
         'priority' => 'N',
         'problem' => 'The streetlamp is broken',
-        'propertyRef' => '00000503',
+        'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
       .with('repairs/00367923')
@@ -298,7 +298,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'requestReference' => '00367923',
         'priority' => 'N',
         'problem' => 'The streetlamp is broken',
-        'propertyRef' => '00000503',
+        'propertyReference' => '00000503',
       )
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -367,7 +367,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'repairs',
       priority: 'N',
       problem: 'The streetlamp is broken',
-      propertyRef: '00000503',
+      propertyReference: '00000503',
     )
   end
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E5 8TE').and_return([property])
-    allow(fake_api).to receive(:get).with('properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
       .and_return(
@@ -170,8 +170,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E5 8TE').and_return([property])
-    allow(fake_api).to receive(:get).with('properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
       .and_return(
@@ -282,8 +282,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E5 8TE').and_return([property])
-    allow(fake_api).to receive(:get).with('properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([property])
+    allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
       .and_return(

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -9,8 +9,8 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E5 8TE').and_return([matching_property])
-    allow(fake_api).to receive(:get).with('properties/zzz').and_return(matching_property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([matching_property])
+    allow(fake_api).to receive(:get).with('v1/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -67,8 +67,8 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('properties?postcode=E5 8TE').and_return([matching_property])
-    allow(fake_api).to receive(:get).with('properties/zzz').and_return(matching_property)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([matching_property])
+    allow(fake_api).to receive(:get).with('v1/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => 'fake_code' }])

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([matching_property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
     allow(fake_api).to receive(:get).with('v1/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
@@ -67,7 +67,7 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return([matching_property])
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
     allow(fake_api).to receive(:get).with('v1/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Users cannot submit incomplete forms' do
   scenario 'when the repair could not be diagnosed' do
     matching_property = {
       'property_reference' => 'zzz',
-      'short_address' => '8A Abersham Road',
+      'address' => '8A Abersham Road',
       'postcode' => 'E5 8TE',
     }
 
@@ -62,7 +62,7 @@ RSpec.feature 'Users cannot submit incomplete forms' do
   scenario 'when the repair was diagnosed' do
     matching_property = {
       'property_reference' => 'zzz',
-      'short_address' => '8A Abersham Road',
+      'address' => '8A Abersham Road',
       'postcode' => 'E5 8TE',
     }
 

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Users cannot submit incomplete forms' do
   scenario 'when the repair could not be diagnosed' do
     matching_property = {
-      'property_reference' => 'zzz',
+      'propertyReference' => 'zzz',
       'address' => '8A Abersham Road',
       'postcode' => 'E5 8TE',
     }
@@ -61,7 +61,7 @@ RSpec.feature 'Users cannot submit incomplete forms' do
 
   scenario 'when the repair was diagnosed' do
     matching_property = {
-      'property_reference' => 'zzz',
+      'propertyReference' => 'zzz',
       'address' => '8A Abersham Road',
       'postcode' => 'E5 8TE',
     }

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RepairParams do
       answers = {
         'address' => {
           'property_reference' => '00034713',
-          'short_address' => 'Ross Court 25',
+          'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
       }

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RepairParams do
     it 'fetches the property reference from answers' do
       answers = {
         'address' => {
-          'property_reference' => '00034713',
+          'propertyReference' => '00034713',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },

--- a/spec/models/repair_spec.rb
+++ b/spec/models/repair_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Repair do
         'orderReference' => '00412371',
         'problem' => 'My bath is broken',
         'priority' => 'N',
-        'propertyRef' => '00034713',
+        'propertyReference' => '00034713',
       }
       expect(Repair.new(repair_data).work_order_reference).to eq '00412371'
     end
@@ -20,7 +20,7 @@ RSpec.describe Repair do
           'requestReference' => '00004578',
           'problem' => 'My bath is broken',
           'priority' => 'N',
-          'propertyRef' => '00034713',
+          'propertyReference' => '00034713',
         }
         expect(Repair.new(repair_data).work_order_reference).to be_nil
       end
@@ -33,7 +33,7 @@ RSpec.describe Repair do
         'requestReference' => '00004578',
         'problem' => 'My bath is broken',
         'priority' => 'N',
-        'propertyRef' => '00034713',
+        'propertyReference' => '00034713',
       }
       expect(Repair.new(repair_data).request_reference).to eq '00004578'
     end
@@ -45,7 +45,7 @@ RSpec.describe Repair do
         'repairRequestReference' => '00004578',
         'problem' => 'My bath is broken',
         'priority' => 'N',
-        'propertyRef' => '00034713',
+        'propertyReference' => '00034713',
       }
       expect(Repair.new(repair_data).request_reference).to eq '00004578'
     end
@@ -56,7 +56,7 @@ RSpec.describe Repair do
       repair_data = {
         'problem' => 'My bath is broken',
         'priority' => 'N',
-        'propertyRef' => '00034713',
+        'propertyReference' => '00034713',
       }
       expect { Repair.new(repair_data).request_reference }.to raise_error(KeyError)
     end

--- a/spec/models/selected_answer_store_spec.rb
+++ b/spec/models/selected_answer_store_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SelectedAnswerStore do
     session = {}
     old_answers = {
       'property_ref' => 'adh389',
-      'address' => 'Flat 1, 35 Church Walk, N16 8QR',
+      'address' => 'Flat 1, 35 Church Walk',
     }
     new_answers = {
       'property_ref' => 'bsg108',

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Confirmation do
       fake_answers = {
         'address' => {
           'property_reference' => '01234567',
-          'short_address' => 'Ross Court 25',
+          'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
       }

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Confirmation do
             'orderReference' => '00412371',
             'problem' => 'My bath is broken',
             'priority' => 'N',
-            'propertyRef' => '00034713',
+            'propertyReference' => '00034713',
           )
         expect(Confirmation.new(request_reference: '00004578', answers: {}, api: fake_api).request_reference)
           .to eq '00412371'
@@ -32,7 +32,7 @@ RSpec.describe Confirmation do
             'requestReference' => '00004578',
             'problem' => 'My bath is broken',
             'priority' => 'N',
-            'propertyRef' => '00034713',
+            'propertyReference' => '00034713',
           )
         expect(Confirmation.new(request_reference: '00004578', answers: {}, api: fake_api).request_reference)
           .to eq '00004578'
@@ -44,7 +44,7 @@ RSpec.describe Confirmation do
     it 'builds an address from the selected answers' do
       fake_answers = {
         'address' => {
-          'property_reference' => '01234567',
+          'propertyReference' => '01234567',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AddressFinder do
     it 'wraps the result of the api call in an object' do
       api_result = [
         {
-          'property_reference' => 'P01234',
+          'propertyReference' => 'P01234',
           'address' => 'Flat 1, 8 Hoxton Square',
           'postcode' => 'N1 6NU',
         },

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe AddressFinder do
         {
           'property_reference' => 'P01234',
           'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+          'postcode' => 'N1 6NU',
         },
       ]
       api = double(list_properties: api_result)

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AddressFinder do
       api_result = [
         {
           'property_reference' => 'P01234',
-          'short_address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+          'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
         },
       ]
       api = double(list_properties: api_result)
@@ -25,7 +25,7 @@ RSpec.describe AddressFinder do
       result = AddressFinder.new(api).find(form)
 
       expect(result.first.property_reference).to eq 'P01234'
-      expect(result.first.short_address).to eq 'Flat 1, 8 Hoxton Square, N1 6NU'
+      expect(result.first.address).to eq 'Flat 1, 8 Hoxton Square, N1 6NU'
     end
   end
 end

--- a/spec/queries/address_finder_spec.rb
+++ b/spec/queries/address_finder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AddressFinder do
       api_result = [
         {
           'property_reference' => 'P01234',
-          'address' => 'Flat 1, 8 Hoxton Square, N1 6NU',
+          'address' => 'Flat 1, 8 Hoxton Square',
           'postcode' => 'N1 6NU',
         },
       ]
@@ -26,7 +26,7 @@ RSpec.describe AddressFinder do
       result = AddressFinder.new(api).find(form)
 
       expect(result.first.property_reference).to eq 'P01234'
-      expect(result.first.address).to eq 'Flat 1, 8 Hoxton Square, N1 6NU'
+      expect(result.first.address).to eq 'Flat 1, 8 Hoxton Square'
     end
   end
 end

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -22,7 +22,7 @@ describe HackneyApi do
         'postcode' => 'N1 1AA',
       }
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:get).with('properties/cre045').and_return(results)
+      allow(json_api).to receive(:get).with('v1/properties/cre045').and_return(results)
       api = HackneyApi.new(json_api)
 
       expect(api.get_property(property_reference: 'cre045')).to eql results

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -5,7 +5,7 @@ describe HackneyApi do
   describe '#list_properties' do
     it 'returns a list of properties' do
       results = [
-        { 'property_reference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road, A1 1AA', 'postcode' => 'A1 1AA' },
+        { 'property_reference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road', 'postcode' => 'A1 1AA' },
       ]
       json_api = double(get: results)
       api = HackneyApi.new(json_api)
@@ -18,7 +18,7 @@ describe HackneyApi do
     it 'returns an individual property' do
       results = {
         'property_reference' => 'cre045',
-        'address' => 'Flat 45, Cheddar Row Estate, Hackney, N1 1AA',
+        'address' => 'Flat 45, Cheddar Row Estate',
         'postcode' => 'N1 1AA',
       }
       json_api = instance_double('JsonApi')

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -7,10 +7,21 @@ describe HackneyApi do
       results = [
         { 'propertyReference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road', 'postcode' => 'A1 1AA' },
       ]
-      json_api = double(get: results)
+      json_api = double(get: { 'results' => results })
       api = HackneyApi.new(json_api)
 
       expect(api.list_properties(postcode: 'A1 1AA')).to eql results
+    end
+
+    it 'raises MissingResults if the "results" key is missing from the response' do
+      response = {
+        'no_result_key_here' => 'epic_fail',
+      }
+
+      json_api = double(get: response)
+      api = HackneyApi.new(json_api)
+
+      expect { api.list_properties(postcode: 'A1 1AA') }.to raise_error(KeyError)
     end
   end
 

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -5,7 +5,7 @@ describe HackneyApi do
   describe '#list_properties' do
     it 'returns a list of properties' do
       results = [
-        { 'property_reference' => 'def567', 'short_address' => 'Flat 8, 1 Aardvark Road, A1 1AA' },
+        { 'property_reference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road, A1 1AA' },
       ]
       json_api = double(get: results)
       api = HackneyApi.new(json_api)
@@ -18,7 +18,7 @@ describe HackneyApi do
     it 'returns an individual property' do
       results = {
         'property_reference' => 'cre045',
-        'short_address' => 'Flat 45, Cheddar Row Estate, Hackney, N1 1AA',
+        'address' => 'Flat 45, Cheddar Row Estate, Hackney, N1 1AA',
       }
       json_api = instance_double('JsonApi')
       allow(json_api).to receive(:get).with('properties/cre045').and_return(results)

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -5,7 +5,7 @@ describe HackneyApi do
   describe '#list_properties' do
     it 'returns a list of properties' do
       results = [
-        { 'property_reference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road, A1 1AA' },
+        { 'property_reference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road, A1 1AA', 'postcode' => 'A1 1AA' },
       ]
       json_api = double(get: results)
       api = HackneyApi.new(json_api)
@@ -19,6 +19,7 @@ describe HackneyApi do
       results = {
         'property_reference' => 'cre045',
         'address' => 'Flat 45, Cheddar Row Estate, Hackney, N1 1AA',
+        'postcode' => 'N1 1AA',
       }
       json_api = instance_double('JsonApi')
       allow(json_api).to receive(:get).with('properties/cre045').and_return(results)

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -5,7 +5,7 @@ describe HackneyApi do
   describe '#list_properties' do
     it 'returns a list of properties' do
       results = [
-        { 'property_reference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road', 'postcode' => 'A1 1AA' },
+        { 'propertyReference' => 'def567', 'address' => 'Flat 8, 1 Aardvark Road', 'postcode' => 'A1 1AA' },
       ]
       json_api = double(get: results)
       api = HackneyApi.new(json_api)
@@ -17,7 +17,7 @@ describe HackneyApi do
   describe '#get_property' do
     it 'returns an individual property' do
       results = {
-        'property_reference' => 'cre045',
+        'propertyReference' => 'cre045',
         'address' => 'Flat 45, Cheddar Row Estate',
         'postcode' => 'N1 1AA',
       }
@@ -38,7 +38,7 @@ describe HackneyApi do
       repair_params = {
         priority: 'U',
         problem: 'It is broken',
-        property_reference: '01234567',
+        propertyReference: '01234567',
       }
       api.create_repair(repair_params)
 
@@ -47,7 +47,7 @@ describe HackneyApi do
           'repairs',
           priority: 'U',
           problem: 'It is broken',
-          property_reference: '01234567',
+          propertyReference: '01234567',
         )
     end
 
@@ -70,7 +70,7 @@ describe HackneyApi do
         'orderReference' => '00412371',
         'problem' => 'My bath is broken',
         'priority' => 'N',
-        'propertyRef' => '00034713',
+        'propertyReference' => '00034713',
       }
       json_api = instance_double('JsonApi')
       allow(json_api).to receive(:get).with('repairs/00045678').and_return(result)

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -66,25 +66,25 @@ RSpec.describe JsonApi do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
         .to_return(
-          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road' }].to_json,
+          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }].to_json,
           headers: { content_type: 'application/json' }
         )
 
       result = json_api.get('properties?postcode=A1 1AA')
 
-      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road' }]
+      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }]
     end
 
     it 'parses a JSON response with an unspecified content_type' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
         .to_return(
-          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road' }].to_json
+          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }].to_json
         )
 
       result = json_api.get('properties?postcode=A1 1AA')
 
-      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road' }]
+      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }]
     end
 
     it 'raises an exception for an invalid json response' do

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -66,25 +66,25 @@ RSpec.describe JsonApi do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
         .to_return(
-          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }].to_json,
+          body: [{ 'propertyReference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }].to_json,
           headers: { content_type: 'application/json' }
         )
 
       result = json_api.get('properties?postcode=A1 1AA')
 
-      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }]
+      expect(result).to eq [{ 'propertyReference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }]
     end
 
     it 'parses a JSON response with an unspecified content_type' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
         .to_return(
-          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }].to_json
+          body: [{ 'propertyReference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }].to_json
         )
 
       result = json_api.get('properties?postcode=A1 1AA')
 
-      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }]
+      expect(result).to eq [{ 'propertyReference' => 'abc123', 'address' => '1 some road', 'postcode' => 'A1 1AA' }]
     end
 
     it 'raises an exception for an invalid json response' do
@@ -129,7 +129,7 @@ RSpec.describe JsonApi do
   describe '#post' do
     it 'sends a JSON payload' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-      request_params = { priority: 'N', problem: 'It is broken', property_reference: '00001234' }
+      request_params = { priority: 'N', problem: 'It is broken', propertyReference: '00001234' }
       request_json = request_params.to_json
       stub_request(:post, 'http://hackney.api:8000/repairs')
         .with(body: request_json)

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -66,25 +66,25 @@ RSpec.describe JsonApi do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
         .to_return(
-          body: [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }].to_json,
+          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road' }].to_json,
           headers: { content_type: 'application/json' }
         )
 
       result = json_api.get('properties?postcode=A1 1AA')
 
-      expect(result).to eq [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }]
+      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road' }]
     end
 
     it 'parses a JSON response with an unspecified content_type' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
         .to_return(
-          body: [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }].to_json
+          body: [{ 'property_reference' => 'abc123', 'address' => '1 some road' }].to_json
         )
 
       result = json_api.get('properties?postcode=A1 1AA')
 
-      expect(result).to eq [{ 'property_reference' => 'abc123', 'short_address' => '1 some road' }]
+      expect(result).to eq [{ 'property_reference' => 'abc123', 'address' => '1 some road' }]
     end
 
     it 'raises an exception for an invalid json response' do

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CreateRepair do
       allow(fake_api).to receive(:create_repair)
       fake_answers = {
         'address' => {
-          'property_reference' => '00034713',
+          'propertyReference' => '00034713',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
@@ -30,7 +30,7 @@ RSpec.describe CreateRepair do
         .with(
           priority: 'N',
           problem: 'My bath is broken (Room: Bathroom)',
-          propertyRef: '00034713',
+          propertyReference: '00034713',
         )
     end
 
@@ -41,12 +41,12 @@ RSpec.describe CreateRepair do
           'requestReference' => '03153917',
           'problem' => 'My bath is broken',
           'priority' => 'N',
-          'propertyRef' => '00034713',
+          'propertyReference' => '00034713',
         )
 
       fake_answers = {
         'address' => {
-          'property_reference' => '00034713',
+          'propertyReference' => '00034713',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
@@ -67,12 +67,12 @@ RSpec.describe CreateRepair do
       .with(
         priority: 'N',
         problem: 'n/a',
-        propertyRef: '00034713'
+        propertyReference: '00034713'
       )
 
     fake_answers = {
       'address' => {
-        'property_reference' => '00034713',
+        'propertyReference' => '00034713',
         'address' => 'Ross Court 25',
         'postcode' => 'E5 8TE',
       },
@@ -91,7 +91,7 @@ RSpec.describe CreateRepair do
       allow(fake_api).to receive(:create_repair)
       fake_answers = {
         'address' => {
-          'property_reference' => '00034713',
+          'propertyReference' => '00034713',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
@@ -110,9 +110,9 @@ RSpec.describe CreateRepair do
         .with(
           priority: 'N',
           problem: 'My bath is broken',
-          propertyRef: '00034713',
+          propertyReference: '00034713',
           repairOrders: [
-            { jobCode: '002034', propertyReference: '00034713' },
+            { jobCode: '002034' },
           ],
         )
     end
@@ -125,11 +125,11 @@ RSpec.describe CreateRepair do
           'orderReference' => '09876543',
           'problem' => 'My bath is broken',
           'priority' => 'N',
-          'propertyRef' => '00034713',
+          'propertyReference' => '00034713',
         )
       fake_answers = {
         'address' => {
-          'property_reference' => '00034713',
+          'propertyReference' => '00034713',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CreateRepair do
       fake_answers = {
         'address' => {
           'property_reference' => '00034713',
-          'short_address' => 'Ross Court 25',
+          'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
         'describe_repair' => {
@@ -47,7 +47,7 @@ RSpec.describe CreateRepair do
       fake_answers = {
         'address' => {
           'property_reference' => '00034713',
-          'short_address' => 'Ross Court 25',
+          'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
         'describe_repair' => {
@@ -73,7 +73,7 @@ RSpec.describe CreateRepair do
     fake_answers = {
       'address' => {
         'property_reference' => '00034713',
-        'short_address' => 'Ross Court 25',
+        'address' => 'Ross Court 25',
         'postcode' => 'E5 8TE',
       },
       'describe_repair' => {
@@ -92,7 +92,7 @@ RSpec.describe CreateRepair do
       fake_answers = {
         'address' => {
           'property_reference' => '00034713',
-          'short_address' => 'Ross Court 25',
+          'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
         'describe_repair' => {
@@ -130,7 +130,7 @@ RSpec.describe CreateRepair do
       fake_answers = {
         'address' => {
           'property_reference' => '00034713',
-          'short_address' => 'Ross Court 25',
+          'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
         'describe_repair' => {


### PR DESCRIPTION
As the Hackney API will shortly be brought inline with the [agreed API standards](https://github.com/LBHackney-IT/api-standards) we need to update our client code which consumes them.

This PR updates the `GET /v1/properties?postcode=` and `GET /v1/properties/...` so they provide the correct parameters in the request and parse the responses correctly.

- Rename `short_address` to `address`
- Rename `property_reference` to `propertyReference`
- Add missing `postcode` to several stubs
- Wrap multiple results in a `results` key
- Prefix endpoints with `/v1`