### PR TITLE
(214) Include callback time in description

### DIFF
--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -4,14 +4,11 @@ class RepairParams
   end
 
   def problem
-    if description.present? && room.present?
-      "#{description} (Room: #{room})"
-    elsif description.present?
-      description
-    elsif room.present?
-      "Room: #{room}"
-    else
-      'n/a'
+    lines = []
+    lines << description if description.present?
+    lines << "Room: #{room}" if room.present?
+    lines.compact.join("\n\n").tap do |output|
+      return 'n/a' if output.empty?
     end
   end
 

--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -6,6 +6,7 @@ class RepairParams
   def problem
     lines = [description]
     lines << "Room: #{room}" if room.present?
+    lines << "Callback requested: between #{callback_time}" if callback_time
     lines.compact.join("\n\n")
   end
 
@@ -35,5 +36,12 @@ class RepairParams
 
   def room
     @answers.dig('room', 'room')
+  end
+
+  def callback_time
+    time = @answers.dig('callback_time', 'callback_time')
+    return if time.blank?
+
+    Callback::TimeSlot.new(time)
   end
 end

--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -4,12 +4,9 @@ class RepairParams
   end
 
   def problem
-    lines = []
-    lines << description if description.present?
+    lines = [description]
     lines << "Room: #{room}" if room.present?
-    lines.compact.join("\n\n").tap do |output|
-      return 'n/a' if output.empty?
-    end
+    lines.compact.join("\n\n")
   end
 
   def property_reference
@@ -31,7 +28,9 @@ class RepairParams
   private
 
   def description
-    @answers.fetch('describe_repair').fetch('description')
+    @answers.fetch('describe_repair').fetch('description').tap do |desc|
+      return 'No description given' if desc.blank?
+    end
   end
 
   def room

--- a/app/presenters/callback.rb
+++ b/app/presenters/callback.rb
@@ -1,27 +1,37 @@
 class Callback
-  class InvalidCallbackTimeError < StandardError; end
-
   attr_reader :request_reference
 
   def initialize(time_slot:, request_reference:)
-    @time_slot = time_slot
+    @time_slot = TimeSlot.new(time_slot)
     @request_reference = request_reference
   end
 
   def time
-    case @time_slot
-    when ['morning']
-      '8am and 12pm'
-    when ['afternoon']
-      '12pm and 5pm'
-    when %w[morning afternoon]
-      '8am and 5pm'
-    else
-      raise InvalidCallbackTimeError
-    end
+    @time_slot.to_s
   end
 
   def to_partial_path
     '/confirmations/callback'
+  end
+
+  class TimeSlot
+    class InvalidCallbackTimeError < StandardError; end
+
+    def initialize(time_slot)
+      @time_slot = time_slot
+    end
+
+    def to_s
+      case @time_slot
+      when ['morning']
+        '8am and 12pm'
+      when ['afternoon']
+        '12pm and 5pm'
+      when %w[morning afternoon]
+        '8am and 5pm'
+      else
+        raise InvalidCallbackTimeError
+      end
+    end
   end
 end

--- a/app/services/callback_time_saver.rb
+++ b/app/services/callback_time_saver.rb
@@ -16,8 +16,8 @@ class CallbackTimeSaver
 
   def persist_answers(form)
     @selected_answer_store.store_selected_answers(
-      :callback_time,
-      callback_time: form.callback_time,
+      'callback_time',
+      'callback_time' => form.callback_time,
     )
   end
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'requestReference' => '00367923',
         'orderReference' => '09124578',
         'priority' => 'N',
-        'problem' => 'My sink is blocked',
+        'problem' => "My sink is blocked\n\nRoom: Kitchen",
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
@@ -25,7 +25,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'requestReference' => '00367923',
         'orderReference' => '09124578',
         'priority' => 'N',
-        'problem' => 'My sink is blocked',
+        'problem' => "My sink is blocked\n\nRoom: Kitchen",
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
@@ -149,7 +149,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: 'My sink is blocked (Room: Kitchen)',
+      problem: "My sink is blocked\n\nRoom: Kitchen",
       propertyReference: '00000503',
       repairOrders: [
         { jobCode: '0078965' },
@@ -177,7 +177,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'requestReference' => '00367923',
         'priority' => 'N',
-        'problem' => 'My sink is blocked',
+        'problem' => "My sink is blocked\n\nRoom: Other",
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
@@ -185,7 +185,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'requestReference' => '00367923',
         'priority' => 'N',
-        'problem' => 'My sink is blocked',
+        'problem' => "My sink is blocked\n\nRoom: Other",
         'propertyReference' => '00000503',
       )
     allow(JsonApi).to receive(:new).and_return(fake_api)
@@ -270,7 +270,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: 'My sink is blocked (Room: Other)',
+      problem: "My sink is blocked\n\nRoom: Other",
       propertyReference: '00000503',
     )
   end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -249,12 +249,13 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     fill_in 'Full name', with: 'John Evans'
     fill_in 'Telephone number', with: '078 98765 432'
     check 'morning (8am - 12pm)'
+    check 'afternoon (12pm - 5pm)'
     click_on 'Continue'
 
     aggregate_failures do
       within '#confirmation' do
         expect(page).to have_content 'Your reference number is 00367923'
-        expect(page).to have_content 'between 8am and 12pm'
+        expect(page).to have_content 'between 8am and 5pm'
       end
 
       within '#summary' do
@@ -270,7 +271,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: "My sink is blocked\n\nRoom: Other",
+      problem: "My sink is blocked\n\nRoom: Other\n\nCallback requested: between 8am and 5pm",
       propertyReference: '00000503',
     )
   end
@@ -289,7 +290,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'requestReference' => '00367923',
         'priority' => 'N',
-        'problem' => 'The streetlamp is broken',
+        'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
@@ -297,7 +298,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'requestReference' => '00367923',
         'priority' => 'N',
-        'problem' => 'The streetlamp is broken',
+        'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
         'propertyReference' => '00000503',
       )
     allow(JsonApi).to receive(:new).and_return(fake_api)
@@ -366,7 +367,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: 'The streetlamp is broken',
+      problem: "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
       propertyReference: '00000503',
     )
   end

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RepairParams do
             'room' => 'Bathroom',
           },
         }
-        expect(RepairParams.new(answers).problem).to eq 'My bath is broken (Room: Bathroom)'
+        expect(RepairParams.new(answers).problem).to eq "My bath is broken\n\nRoom: Bathroom"
       end
 
       it 'describes the room if there was no description' do

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RepairParams do
             'description' => '',
           },
         }
-        expect(RepairParams.new(answers).problem).to eq 'n/a'
+        expect(RepairParams.new(answers).problem).to eq 'No description given'
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe RepairParams do
             'room' => 'Bathroom',
           },
         }
-        expect(RepairParams.new(answers).problem).to eq 'Room: Bathroom'
+        expect(RepairParams.new(answers).problem).to eq "No description given\n\nRoom: Bathroom"
       end
     end
   end

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'active_support/core_ext/object/blank'
+require 'app/presenters/callback'
 require 'app/models/repair_params'
 
 RSpec.describe RepairParams do
@@ -47,6 +48,32 @@ RSpec.describe RepairParams do
           },
         }
         expect(RepairParams.new(answers).problem).to eq "No description given\n\nRoom: Bathroom"
+      end
+    end
+
+    context 'if a callback was requested' do
+      it 'includes the callback info in the description' do
+        answers = {
+          'describe_repair' => {
+            'description' => 'My bath is broken',
+          },
+          'callback_time' => {
+            'callback_time' => ['morning'],
+          },
+        }
+        expect(RepairParams.new(answers).problem).to eq "My bath is broken\n\nCallback requested: between 8am and 12pm"
+      end
+
+      it 'includes the callback info if there was no description' do
+        answers = {
+          'describe_repair' => {
+            'description' => '',
+          },
+          'callback_time' => {
+            'callback_time' => ['morning'],
+          },
+        }
+        expect(RepairParams.new(answers).problem).to eq "No description given\n\nCallback requested: between 8am and 12pm"
       end
     end
   end

--- a/spec/presenters/callback_spec.rb
+++ b/spec/presenters/callback_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe Callback do
     context 'when the stored callback time was a string (not an array)' do
       it 'raises an exception' do
         expect { Callback.new(time_slot: 'morning', request_reference: '00000000').time }
-          .to raise_error(Callback::InvalidCallbackTimeError)
+          .to raise_error(Callback::TimeSlot::InvalidCallbackTimeError)
       end
     end
 
     context 'when the stored callback time was not recognised' do
       it 'raises an exception' do
         expect { Callback.new(time_slot: ['teatime'], request_reference: '00000000').time }
-          .to raise_error(Callback::InvalidCallbackTimeError)
+          .to raise_error(Callback::TimeSlot::InvalidCallbackTimeError)
       end
     end
   end

--- a/spec/services/callback_time_saver_spec.rb
+++ b/spec/services/callback_time_saver_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CallbackTimeSaver do
                                   valid?: true,
                                   full_name: 'Alan Stubbs',
                                   telephone_number: '0456765432',
-                                  callback_time: ['morning'])
+                                  'callback_time' => ['morning'])
 
       saver = CallbackTimeSaver.new(selected_answer_store: fake_answer_store)
       saver.save(fake_form)
@@ -18,8 +18,8 @@ RSpec.describe CallbackTimeSaver do
       expect(fake_answer_store)
         .to have_received(:store_selected_answers)
         .with(
-          :callback_time,
-          callback_time: ['morning'],
+          'callback_time',
+          'callback_time' => ['morning'],
         )
     end
 
@@ -30,7 +30,7 @@ RSpec.describe CallbackTimeSaver do
                                   valid?: true,
                                   full_name: 'Alan Stubbs',
                                   telephone_number: '0456765432',
-                                  callback_time: ['morning'])
+                                  'callback_time' => ['morning'])
 
       saver = CallbackTimeSaver.new(selected_answer_store: fake_answer_store)
       expect(saver.save(fake_form)).to eq true
@@ -44,7 +44,7 @@ RSpec.describe CallbackTimeSaver do
                                     valid?: false,
                                     full_name: '',
                                     telephone_number: '',
-                                    callback_time: [])
+                                    'callback_time' => [])
 
         saver = CallbackTimeSaver.new(selected_answer_store: fake_answer_store)
         saver.save(fake_form)
@@ -59,7 +59,7 @@ RSpec.describe CallbackTimeSaver do
                                     valid?: false,
                                     full_name: '',
                                     telephone_number: '',
-                                    callback_time: [])
+                                    'callback_time' => [])
 
         saver = CallbackTimeSaver.new(selected_answer_store: fake_answer_store)
         expect(saver.save(fake_form)).to eq false

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CreateRepair do
       expect(fake_api).to have_received(:create_repair)
         .with(
           priority: 'N',
-          problem: 'My bath is broken (Room: Bathroom)',
+          problem: "My bath is broken\n\nRoom: Bathroom",
           propertyReference: '00034713',
         )
     end

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CreateRepair do
     expect(fake_api).to receive(:create_repair)
       .with(
         priority: 'N',
-        problem: 'n/a',
+        problem: 'No description given',
         propertyReference: '00034713'
       )
 


### PR DESCRIPTION
Format it in the same way as it is displayed on the confirmation page.

Includes fix: Callback time gets saved as a symbol, and read out as a
symbol (we're expecting a string key). This is because it hasn't been saved
to the session cookie and read out again (that's what casts the symbols to
strings).

We should probably write everything as strings, since the casting of
symbols to strings is a little confusing, but that should happen separately
to this PR.