### PR TITLE
(216) Repairs endpoint fixes

### DIFF
--- a/app/models/repair.rb
+++ b/app/models/repair.rb
@@ -4,9 +4,7 @@ class Repair
   end
 
   def request_reference
-    @repair_data.fetch('requestReference') do |_key|
-      @repair_data.fetch('repairRequestReference')
-    end
+    @repair_data.fetch('repairRequestReference')
   end
 
   def work_order_reference

--- a/app/models/repair.rb
+++ b/app/models/repair.rb
@@ -8,6 +8,8 @@ class Repair
   end
 
   def work_order_reference
-    @repair_data['orderReference']
+    return nil unless @repair_data.key?('workOrders')
+
+    @repair_data.fetch('workOrders')&.first&.fetch('workOrderReference')
   end
 end

--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -3,7 +3,7 @@ class RepairParams
     @answers = answers
   end
 
-  def problem
+  def problem_description
     lines = [description]
     lines << "Room: #{room}" if room.present?
     lines << "Callback requested: between #{callback_time}" if callback_time

--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -26,6 +26,14 @@ class RepairParams
     sor_code.present?
   end
 
+  def contact_full_name
+    @answers.fetch('contact_details').fetch('full_name')
+  end
+
+  def contact_telephone_number
+    @answers.fetch('contact_details').fetch('telephone_number')
+  end
+
   private
 
   def description

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -13,11 +13,11 @@ class HackneyApi
   end
 
   def create_repair(repair_params)
-    @json_api.post('repairs', repair_params)
+    @json_api.post('v1/repairs', repair_params)
   end
 
   def get_repair(repair_request_reference:)
-    @json_api.get('repairs/' + repair_request_reference)
+    @json_api.get('v1/repairs/' + repair_request_reference)
   end
 
   def list_available_appointments(work_order_reference:)

--- a/app/services/contact_details_saver.rb
+++ b/app/services/contact_details_saver.rb
@@ -16,9 +16,9 @@ class ContactDetailsSaver
 
   def persist_answers(form)
     @selected_answer_store.store_selected_answers(
-      :contact_details,
-      full_name: form.full_name,
-      telephone_number: form.telephone_number,
+      'contact_details',
+      'full_name' => form.full_name,
+      'telephone_number' => form.telephone_number
     )
   end
 end

--- a/app/services/create_repair.rb
+++ b/app/services/create_repair.rb
@@ -17,14 +17,14 @@ class CreateRepair
       problemDescription: params.problem_description,
       propertyReference: params.property_reference,
     }.tap do |hash|
-      hash[:repairOrders] = create_work_order_params(params) if params.sor_code
+      hash[:workOrders] = create_work_order_params(params) if params.sor_code
     end
   end
 
   def create_work_order_params(params)
     [
       {
-        jobCode: params.sor_code,
+        sorCode: params.sor_code,
       },
     ]
   end

--- a/app/services/create_repair.rb
+++ b/app/services/create_repair.rb
@@ -14,7 +14,7 @@ class CreateRepair
   def create_repair_params(params)
     {
       priority: params.priority,
-      problem: params.problem,
+      problemDescription: params.problem_description,
       propertyReference: params.property_reference,
     }.tap do |hash|
       hash[:repairOrders] = create_work_order_params(params) if params.sor_code

--- a/app/services/create_repair.rb
+++ b/app/services/create_repair.rb
@@ -16,6 +16,7 @@ class CreateRepair
       priority: params.priority,
       problemDescription: params.problem_description,
       propertyReference: params.property_reference,
+      contact: create_contact_params(params),
     }.tap do |hash|
       hash[:workOrders] = create_work_order_params(params) if params.sor_code
     end
@@ -27,5 +28,12 @@ class CreateRepair
         sorCode: params.sor_code,
       },
     ]
+  end
+
+  def create_contact_params(params)
+    {
+      name: params.contact_full_name,
+      telephoneNumber: params.contact_telephone_number,
+    }
   end
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('repairs', anything)
+      .with('v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -25,7 +25,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         ]
       )
     allow(fake_api).to receive(:get)
-      .with('repairs/00367923')
+      .with('v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -157,7 +157,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'repairs',
+      'v1/repairs',
       priority: 'N',
       problemDescription: "My sink is blocked\n\nRoom: Kitchen",
       propertyReference: '00000503',
@@ -187,7 +187,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('repairs', anything)
+      .with('v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -195,7 +195,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
-      .with('repairs/00367923')
+      .with('v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -283,7 +283,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'repairs',
+      'v1/repairs',
       priority: 'N',
       problemDescription: "My sink is blocked\n\nRoom: Other\n\nCallback requested: between 8am and 5pm",
       propertyReference: '00000503',
@@ -304,7 +304,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('repairs', anything)
+      .with('v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -312,7 +312,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
-      .with('repairs/00367923')
+      .with('v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -383,7 +383,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'repairs',
+      'v1/repairs',
       priority: 'N',
       problemDescription: "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
       propertyReference: '00000503',

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: "My sink is blocked\n\nRoom: Kitchen",
+      problemDescription: "My sink is blocked\n\nRoom: Kitchen",
       propertyReference: '00000503',
       repairOrders: [
         { jobCode: '0078965' },
@@ -271,7 +271,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: "My sink is blocked\n\nRoom: Other\n\nCallback requested: between 8am and 5pm",
+      problemDescription: "My sink is blocked\n\nRoom: Other\n\nCallback requested: between 8am and 5pm",
       propertyReference: '00000503',
     )
   end
@@ -367,7 +367,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'repairs',
       priority: 'N',
-      problem: "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
+      problemDescription: "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
       propertyReference: '00000503',
     )
   end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
       .and_return(
-        'requestReference' => '00367923',
+        'repairRequestReference' => '00367923',
         'orderReference' => '09124578',
         'priority' => 'N',
         'problem' => "My sink is blocked\n\nRoom: Kitchen",
@@ -22,7 +22,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:get)
       .with('repairs/00367923')
       .and_return(
-        'requestReference' => '00367923',
+        'repairRequestReference' => '00367923',
         'orderReference' => '09124578',
         'priority' => 'N',
         'problem' => "My sink is blocked\n\nRoom: Kitchen",
@@ -175,7 +175,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
       .and_return(
-        'requestReference' => '00367923',
+        'repairRequestReference' => '00367923',
         'priority' => 'N',
         'problem' => "My sink is blocked\n\nRoom: Other",
         'propertyReference' => '00000503',
@@ -183,7 +183,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:get)
       .with('repairs/00367923')
       .and_return(
-        'requestReference' => '00367923',
+        'repairRequestReference' => '00367923',
         'priority' => 'N',
         'problem' => "My sink is blocked\n\nRoom: Other",
         'propertyReference' => '00000503',
@@ -288,7 +288,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:post)
       .with('repairs', anything)
       .and_return(
-        'requestReference' => '00367923',
+        'repairRequestReference' => '00367923',
         'priority' => 'N',
         'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
         'propertyReference' => '00000503',
@@ -296,7 +296,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:get)
       .with('repairs/00367923')
       .and_return(
-        'requestReference' => '00367923',
+        'repairRequestReference' => '00367923',
         'priority' => 'N',
         'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
         'propertyReference' => '00000503',

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -151,6 +151,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       priority: 'N',
       problemDescription: "My sink is blocked\n\nRoom: Kitchen",
       propertyReference: '00000503',
+      contact: {
+        name: 'John Evans',
+        telephoneNumber: '078 98765 432',
+      },
       workOrders: [
         { sorCode: '0078965' },
       ]
@@ -273,6 +277,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       priority: 'N',
       problemDescription: "My sink is blocked\n\nRoom: Other\n\nCallback requested: between 8am and 5pm",
       propertyReference: '00000503',
+      contact: {
+        name: 'John Evans',
+        telephoneNumber: '078 98765 432',
+      },
     )
   end
 
@@ -369,6 +377,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       priority: 'N',
       problemDescription: "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
       propertyReference: '00000503',
+      contact: {
+        name: 'John Evans',
+        telephoneNumber: '078 98765 432',
+      },
     )
   end
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -151,8 +151,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       priority: 'N',
       problemDescription: "My sink is blocked\n\nRoom: Kitchen",
       propertyReference: '00000503',
-      repairOrders: [
-        { jobCode: '0078965' },
+      workOrders: [
+        { sorCode: '0078965' },
       ]
     )
 

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -14,19 +14,29 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .with('repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
-        'orderReference' => '09124578',
         'priority' => 'N',
         'problem' => "My sink is blocked\n\nRoom: Kitchen",
         'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ]
       )
     allow(fake_api).to receive(:get)
       .with('repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
-        'orderReference' => '09124578',
         'priority' => 'N',
         'problem' => "My sink is blocked\n\nRoom: Kitchen",
         'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ]
       )
     allow(fake_api).to receive(:get)
       .with('work_orders/09124578/appointments')

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -4,14 +4,14 @@ require 'app/presenters/callback'
 require 'app/models/repair_params'
 
 RSpec.describe RepairParams do
-  describe '#problem' do
+  describe '#problem_description' do
     it 'fetches the description from answers' do
       answers = {
         'describe_repair' => {
           'description' => 'My bath is broken',
         },
       }
-      expect(RepairParams.new(answers).problem).to eq 'My bath is broken'
+      expect(RepairParams.new(answers).problem_description).to eq 'My bath is broken'
     end
 
     context 'if no description was provided' do
@@ -21,7 +21,7 @@ RSpec.describe RepairParams do
             'description' => '',
           },
         }
-        expect(RepairParams.new(answers).problem).to eq 'No description given'
+        expect(RepairParams.new(answers).problem_description).to eq 'No description given'
       end
     end
 
@@ -35,7 +35,7 @@ RSpec.describe RepairParams do
             'room' => 'Bathroom',
           },
         }
-        expect(RepairParams.new(answers).problem).to eq "My bath is broken\n\nRoom: Bathroom"
+        expect(RepairParams.new(answers).problem_description).to eq "My bath is broken\n\nRoom: Bathroom"
       end
 
       it 'describes the room if there was no description' do
@@ -47,7 +47,7 @@ RSpec.describe RepairParams do
             'room' => 'Bathroom',
           },
         }
-        expect(RepairParams.new(answers).problem).to eq "No description given\n\nRoom: Bathroom"
+        expect(RepairParams.new(answers).problem_description).to eq "No description given\n\nRoom: Bathroom"
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe RepairParams do
             'callback_time' => ['morning'],
           },
         }
-        expect(RepairParams.new(answers).problem).to eq "My bath is broken\n\nCallback requested: between 8am and 12pm"
+        expect(RepairParams.new(answers).problem_description).to eq "My bath is broken\n\nCallback requested: between 8am and 12pm"
       end
 
       it 'includes the callback info if there was no description' do
@@ -73,7 +73,7 @@ RSpec.describe RepairParams do
             'callback_time' => ['morning'],
           },
         }
-        expect(RepairParams.new(answers).problem).to eq "No description given\n\nCallback requested: between 8am and 12pm"
+        expect(RepairParams.new(answers).problem_description).to eq "No description given\n\nCallback requested: between 8am and 12pm"
       end
     end
   end

--- a/spec/models/repair_spec.rb
+++ b/spec/models/repair_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Repair do
       repair_data = {
         'repairRequestReference' => '00004578',
         'orderReference' => '00412371',
-        'problem' => 'My bath is broken',
+        'problemDescription' => 'My bath is broken',
         'priority' => 'N',
         'propertyReference' => '00034713',
       }
@@ -18,7 +18,7 @@ RSpec.describe Repair do
       it 'is nil' do
         repair_data = {
           'repairRequestReference' => '00004578',
-          'problem' => 'My bath is broken',
+          'problemDescription' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
         }
@@ -31,7 +31,7 @@ RSpec.describe Repair do
     it 'returns the request reference from the repair' do
       repair_data = {
         'repairRequestReference' => '00004578',
-        'problem' => 'My bath is broken',
+        'problemDescription' => 'My bath is broken',
         'priority' => 'N',
         'propertyReference' => '00034713',
       }
@@ -42,7 +42,7 @@ RSpec.describe Repair do
   context 'when there is no reference in the data' do
     it 'raises an error' do
       repair_data = {
-        'problem' => 'My bath is broken',
+        'problemDescription' => 'My bath is broken',
         'priority' => 'N',
         'propertyReference' => '00034713',
       }

--- a/spec/models/repair_spec.rb
+++ b/spec/models/repair_spec.rb
@@ -6,10 +6,17 @@ RSpec.describe Repair do
     it 'returns the first work order reference from the repair' do
       repair_data = {
         'repairRequestReference' => '00004578',
-        'orderReference' => '00412371',
         'problemDescription' => 'My bath is broken',
         'priority' => 'N',
         'propertyReference' => '00034713',
+        'workOrders' => [
+          {
+            'workOrderReference' => '00412371',
+          },
+          {
+            'workOrderReference' => '88888888',
+          },
+        ],
       }
       expect(Repair.new(repair_data).work_order_reference).to eq '00412371'
     end
@@ -22,6 +29,20 @@ RSpec.describe Repair do
           'priority' => 'N',
           'propertyReference' => '00034713',
         }
+        expect(Repair.new(repair_data).work_order_reference).to be_nil
+      end
+    end
+
+    context 'when workOrders is returned, but is empty' do
+      it 'is nil' do
+        repair_data = {
+          'repairRequestReference' => '00004578',
+          'problemDescription' => 'My bath is broken',
+          'priority' => 'N',
+          'propertyReference' => '00034713',
+          'workOrders' => [],
+        }
+
         expect(Repair.new(repair_data).work_order_reference).to be_nil
       end
     end

--- a/spec/models/repair_spec.rb
+++ b/spec/models/repair_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Repair do
   describe '#work_order_reference' do
     it 'returns the first work order reference from the repair' do
       repair_data = {
-        'requestReference' => '00004578',
+        'repairRequestReference' => '00004578',
         'orderReference' => '00412371',
         'problem' => 'My bath is broken',
         'priority' => 'N',
@@ -17,7 +17,7 @@ RSpec.describe Repair do
     context 'when there are no work orders' do
       it 'is nil' do
         repair_data = {
-          'requestReference' => '00004578',
+          'repairRequestReference' => '00004578',
           'problem' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
@@ -28,18 +28,6 @@ RSpec.describe Repair do
   end
 
   describe '#request_reference' do
-    it 'returns the request reference from the repair' do
-      repair_data = {
-        'requestReference' => '00004578',
-        'problem' => 'My bath is broken',
-        'priority' => 'N',
-        'propertyReference' => '00034713',
-      }
-      expect(Repair.new(repair_data).request_reference).to eq '00004578'
-    end
-  end
-
-  context 'when there is a reference with an outdated key' do
     it 'returns the request reference from the repair' do
       repair_data = {
         'repairRequestReference' => '00004578',

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Confirmation do
         allow(fake_api).to receive(:get_repair)
           .with(repair_request_reference: '00004578')
           .and_return(
-            'requestReference' => '00004578',
+            'repairRequestReference' => '00004578',
             'orderReference' => '00412371',
             'problem' => 'My bath is broken',
             'priority' => 'N',
@@ -29,7 +29,7 @@ RSpec.describe Confirmation do
         allow(fake_api).to receive(:get_repair)
           .with(repair_request_reference: '00004578')
           .and_return(
-            'requestReference' => '00004578',
+            'repairRequestReference' => '00004578',
             'problem' => 'My bath is broken',
             'priority' => 'N',
             'propertyReference' => '00034713',

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_support/inflector'
 require 'app/models/repair'
 require 'app/presenters/callback'
 require 'app/presenters/appointment_presenter'
@@ -13,10 +14,15 @@ RSpec.describe Confirmation do
           .with(repair_request_reference: '00004578')
           .and_return(
             'repairRequestReference' => '00004578',
-            'orderReference' => '00412371',
             'problemDescription' => 'My bath is broken',
             'priority' => 'N',
             'propertyReference' => '00034713',
+            'workOrders' => [
+              {
+                'sorCode' => '20110010',
+                'workOrderReference' => '00412371',
+              },
+            ]
           )
         expect(Confirmation.new(request_reference: '00004578', answers: {}, api: fake_api).request_reference)
           .to eq '00412371'

--- a/spec/presenters/confirmation_spec.rb
+++ b/spec/presenters/confirmation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Confirmation do
           .and_return(
             'repairRequestReference' => '00004578',
             'orderReference' => '00412371',
-            'problem' => 'My bath is broken',
+            'problemDescription' => 'My bath is broken',
             'priority' => 'N',
             'propertyReference' => '00034713',
           )
@@ -30,7 +30,7 @@ RSpec.describe Confirmation do
           .with(repair_request_reference: '00004578')
           .and_return(
             'repairRequestReference' => '00004578',
-            'problem' => 'My bath is broken',
+            'problemDescription' => 'My bath is broken',
             'priority' => 'N',
             'propertyReference' => '00034713',
           )

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -48,7 +48,7 @@ describe HackneyApi do
       api = HackneyApi.new(json_api)
       repair_params = {
         priority: 'U',
-        problem: 'It is broken',
+        problemDescription: 'It is broken',
         propertyReference: '01234567',
       }
       api.create_repair(repair_params)
@@ -57,7 +57,7 @@ describe HackneyApi do
         .with(
           'repairs',
           priority: 'U',
-          problem: 'It is broken',
+          problemDescription: 'It is broken',
           propertyReference: '01234567',
         )
     end
@@ -79,7 +79,7 @@ describe HackneyApi do
       result = {
         'repairRequestReference' => '00045678',
         'orderReference' => '00412371',
-        'problem' => 'My bath is broken',
+        'problemDescription' => 'My bath is broken',
         'priority' => 'N',
         'propertyReference' => '00034713',
       }

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -43,7 +43,7 @@ describe HackneyApi do
   describe '#create_repair' do
     it 'sends repair creation parameters' do
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:post).with('repairs', anything)
+      allow(json_api).to receive(:post).with('v1/repairs', anything)
 
       api = HackneyApi.new(json_api)
       repair_params = {
@@ -55,7 +55,7 @@ describe HackneyApi do
 
       expect(json_api).to have_received(:post)
         .with(
-          'repairs',
+          'v1/repairs',
           priority: 'U',
           problemDescription: 'It is broken',
           propertyReference: '01234567',
@@ -66,7 +66,7 @@ describe HackneyApi do
       json_api = instance_double('JsonApi')
       result = double('api result')
       allow(json_api).to receive(:post)
-        .with('repairs', anything)
+        .with('v1/repairs', anything)
         .and_return result
 
       api = HackneyApi.new(json_api)
@@ -89,7 +89,7 @@ describe HackneyApi do
         ],
       }
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:get).with('repairs/00045678').and_return(result)
+      allow(json_api).to receive(:get).with('v1/repairs/00045678').and_return(result)
       api = HackneyApi.new(json_api)
 
       expect(api.get_repair(repair_request_reference: '00045678')).to eql result

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -77,7 +77,7 @@ describe HackneyApi do
   describe '#get_repair' do
     it 'returns an individual repair' do
       result = {
-        'requestReference' => '00045678',
+        'repairRequestReference' => '00045678',
         'orderReference' => '00412371',
         'problem' => 'My bath is broken',
         'priority' => 'N',

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -78,10 +78,15 @@ describe HackneyApi do
     it 'returns an individual repair' do
       result = {
         'repairRequestReference' => '00045678',
-        'orderReference' => '00412371',
         'problemDescription' => 'My bath is broken',
         'priority' => 'N',
         'propertyReference' => '00034713',
+        'workOrders' => [
+          {
+            'sorCode' => '20164242',
+            'workOrderReference' => '00412371',
+          },
+        ],
       }
       json_api = instance_double('JsonApi')
       allow(json_api).to receive(:get).with('repairs/00045678').and_return(result)

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe JsonApi do
   describe '#post' do
     it 'sends a JSON payload' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-      request_params = { priority: 'N', problem: 'It is broken', propertyReference: '00001234' }
+      request_params = { priority: 'N', problemDescription: 'It is broken', propertyReference: '00001234' }
       request_json = request_params.to_json
       stub_request(:post, 'http://hackney.api:8000/repairs')
         .with(body: request_json)

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -116,11 +116,11 @@ RSpec.describe JsonApi do
           api_cert: TestSsl.certificate,
           api_key: TestSsl.key,
         )
-        stub_request(:get, 'http://hackney.api:8000/repairs/00012345')
+        stub_request(:get, 'http://hackney.api:8000/v1/repairs/00012345')
 
-        json_api.get('repairs/00012345')
+        json_api.get('v1/repairs/00012345')
 
-        expect(a_request(:get, 'http://hackney.api:8000/repairs/00012345'))
+        expect(a_request(:get, 'http://hackney.api:8000/v1/repairs/00012345'))
           .to have_been_made.once
       end
     end
@@ -131,12 +131,12 @@ RSpec.describe JsonApi do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       request_params = { priority: 'N', problemDescription: 'It is broken', propertyReference: '00001234' }
       request_json = request_params.to_json
-      stub_request(:post, 'http://hackney.api:8000/repairs')
+      stub_request(:post, 'http://hackney.api:8000/v1/repairs')
         .with(body: request_json)
 
-      json_api.post('repairs', request_params)
+      json_api.post('v1/repairs', request_params)
 
-      expect(a_request(:post, 'http://hackney.api:8000/repairs')
+      expect(a_request(:post, 'http://hackney.api:8000/v1/repairs')
         .with(
           body: request_json,
           headers: { content_type: 'application/json' }
@@ -146,20 +146,20 @@ RSpec.describe JsonApi do
     it 'parses a JSON response' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       response_params = { repair_request_id: '00045678' }
-      stub_request(:post, 'http://hackney.api:8000/repairs')
+      stub_request(:post, 'http://hackney.api:8000/v1/repairs')
         .to_return(body: response_params.to_json)
 
-      result = json_api.post('repairs', {})
+      result = json_api.post('v1/repairs', {})
       expect(result).to eq('repair_request_id' => '00045678')
     end
 
     context 'when the response was not valid JSON' do
       it 'raises an exception' do
         json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:post, 'http://hackney.api:8000/repairs')
+        stub_request(:post, 'http://hackney.api:8000/v1/repairs')
           .to_return(body: 'not found')
 
-        expect { json_api.post('/repairs', {}) }
+        expect { json_api.post('/v1/repairs', {}) }
           .to raise_error(JsonApi::InvalidResponseError, "765: unexpected token at 'not found'")
       end
     end

--- a/spec/services/contact_details_saver_spec.rb
+++ b/spec/services/contact_details_saver_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe ContactDetailsSaver do
       expect(fake_answer_store)
         .to have_received(:store_selected_answers)
         .with(
-          :contact_details,
-          full_name: 'Alan Stubbs',
-          telephone_number: '0456765432',
+          'contact_details',
+          'full_name' => 'Alan Stubbs',
+          'telephone_number' => '0456765432',
         )
     end
 

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe CreateRepair do
       allow(fake_api).to receive(:create_repair)
         .and_return(
           'repairRequestReference' => '03153917',
-          'orderReference' => '09876543',
           'problemDescription' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
@@ -162,6 +161,12 @@ RSpec.describe CreateRepair do
             'name' => 'Jo Apple',
             'telephoneNumber' => '07900 880110',
           },
+          'workOrders' => [
+            {
+              'sorCode' => '20012345',
+              'workOrderReference' => '09876543',
+            },
+          ],
         )
       fake_answers = {
         'address' => {

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CreateRepair do
       expect(fake_api).to have_received(:create_repair)
         .with(
           priority: 'N',
-          problem: "My bath is broken\n\nRoom: Bathroom",
+          problemDescription: "My bath is broken\n\nRoom: Bathroom",
           propertyReference: '00034713',
         )
     end
@@ -39,7 +39,7 @@ RSpec.describe CreateRepair do
       allow(fake_api).to receive(:create_repair)
         .and_return(
           'repairRequestReference' => '03153917',
-          'problem' => 'My bath is broken',
+          'problemDescription' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
         )
@@ -66,7 +66,7 @@ RSpec.describe CreateRepair do
     expect(fake_api).to receive(:create_repair)
       .with(
         priority: 'N',
-        problem: 'No description given',
+        problemDescription: 'No description given',
         propertyReference: '00034713'
       )
 
@@ -109,7 +109,7 @@ RSpec.describe CreateRepair do
       expect(fake_api).to have_received(:create_repair)
         .with(
           priority: 'N',
-          problem: 'My bath is broken',
+          problemDescription: 'My bath is broken',
           propertyReference: '00034713',
           repairOrders: [
             { jobCode: '002034' },
@@ -123,7 +123,7 @@ RSpec.describe CreateRepair do
         .and_return(
           'repairRequestReference' => '03153917',
           'orderReference' => '09876543',
-          'problem' => 'My bath is broken',
+          'problemDescription' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
         )

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe CreateRepair do
         )
     end
 
-    it 'returns a result containing the request reference' do
+    it 'returns a result containing the repair request reference' do
       fake_api = instance_double('HackneyApi')
       allow(fake_api).to receive(:create_repair)
         .and_return(
-          'requestReference' => '03153917',
+          'repairRequestReference' => '03153917',
           'problem' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
@@ -117,11 +117,11 @@ RSpec.describe CreateRepair do
         )
     end
 
-    it 'returns a result which exposes the request reference' do
+    it 'returns a result which exposes the repair request reference' do
       fake_api = instance_double('HackneyApi')
       allow(fake_api).to receive(:create_repair)
         .and_return(
-          'requestReference' => '03153917',
+          'repairRequestReference' => '03153917',
           'orderReference' => '09876543',
           'problem' => 'My bath is broken',
           'priority' => 'N',

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe CreateRepair do
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
+        'contact_details' => {
+          'full_name' => 'Jo Bloggs',
+          'telephone_number' => '07900 123456',
+        },
         'describe_repair' => {
           'description' => 'My bath is broken',
         },
@@ -31,6 +35,10 @@ RSpec.describe CreateRepair do
           priority: 'N',
           problemDescription: "My bath is broken\n\nRoom: Bathroom",
           propertyReference: '00034713',
+          contact: {
+            name: 'Jo Bloggs',
+            telephoneNumber: '07900 123456',
+          }
         )
     end
 
@@ -42,6 +50,10 @@ RSpec.describe CreateRepair do
           'problemDescription' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
+          'contact' => {
+            'name' => 'Jo Apple',
+            'telephoneNumber' => '07900 880110',
+          },
         )
 
       fake_answers = {
@@ -49,6 +61,10 @@ RSpec.describe CreateRepair do
           'propertyReference' => '00034713',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
+        },
+        'contact_details' => {
+          'full_name' => 'Jo Apple',
+          'telephone_number' => '07900 880110',
         },
         'describe_repair' => {
           'description' => 'My bath is broken',
@@ -67,7 +83,11 @@ RSpec.describe CreateRepair do
       .with(
         priority: 'N',
         problemDescription: 'No description given',
-        propertyReference: '00034713'
+        propertyReference: '00034713',
+        contact: {
+          name: 'Jo Bloggs',
+          telephoneNumber: '07900 123456',
+        }
       )
 
     fake_answers = {
@@ -75,6 +95,10 @@ RSpec.describe CreateRepair do
         'propertyReference' => '00034713',
         'address' => 'Ross Court 25',
         'postcode' => 'E5 8TE',
+      },
+      'contact_details' => {
+        'full_name' => 'Jo Bloggs',
+        'telephone_number' => '07900 123456',
       },
       'describe_repair' => {
         'description' => '',
@@ -95,6 +119,10 @@ RSpec.describe CreateRepair do
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
         },
+        'contact_details' => {
+          'full_name' => 'Alex Doe',
+          'telephone_number' => '020 8534 1234',
+        },
         'describe_repair' => {
           'description' => 'My bath is broken',
         },
@@ -111,6 +139,10 @@ RSpec.describe CreateRepair do
           priority: 'N',
           problemDescription: 'My bath is broken',
           propertyReference: '00034713',
+          contact: {
+            name: 'Alex Doe',
+            telephoneNumber: '020 8534 1234',
+          },
           workOrders: [
             { sorCode: '002034' },
           ],
@@ -126,12 +158,20 @@ RSpec.describe CreateRepair do
           'problemDescription' => 'My bath is broken',
           'priority' => 'N',
           'propertyReference' => '00034713',
+          'contact' => {
+            'name' => 'Jo Apple',
+            'telephoneNumber' => '07900 880110',
+          },
         )
       fake_answers = {
         'address' => {
           'propertyReference' => '00034713',
           'address' => 'Ross Court 25',
           'postcode' => 'E5 8TE',
+        },
+        'contact_details' => {
+          'full_name' => 'Jo Apple',
+          'telephone_number' => '07900 880110',
         },
         'describe_repair' => {
           'description' => 'My bath is broken',

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe CreateRepair do
           priority: 'N',
           problemDescription: 'My bath is broken',
           propertyReference: '00034713',
-          repairOrders: [
-            { jobCode: '002034' },
+          workOrders: [
+            { sorCode: '002034' },
           ],
         )
     end


### PR DESCRIPTION
Update the `GET /v1/repairs/:repairRequestReference` and `POST /v1/repairs/` so they provide the correct parameters in the request and parse the responses correctly.

- Rename `requestReference` to `repairRequestReference`
- Rename `problem` to `problemDescription`
- Change from `repairOrders` with a `jobCode` to `workOrders` with a `sorCode`
- Rename `orderReference` to `workOrderReference`, and extract this differently as it's now nested inside the `workOrders` array in the response
- Include contact `name `and `telephoneNumber` when submitting a repair (NB: callback time is being added separately in #54)
- Prefix the repairs routes with `v1/` as per the agreed standards