### PR TITLE
(201) Use 'midday' instead of '12pm'

### DIFF
--- a/app/presenters/appointment_presenter.rb
+++ b/app/presenters/appointment_presenter.rb
@@ -13,7 +13,7 @@ class AppointmentPresenter
   end
 
   def description
-    "#{day_of_week} #{begin_time}-#{end_time} (#{day} #{month})"
+    "#{day_of_week} #{begin_time} to #{end_time} (#{day} #{month})"
   end
 
   def date

--- a/app/presenters/appointment_presenter.rb
+++ b/app/presenters/appointment_presenter.rb
@@ -59,6 +59,7 @@ class AppointmentPresenter
   end
 
   def friendly_time(time)
+    return 'midday' if time == time.midday
     format = if time.strftime('%M').to_i.zero?
                '%l%P'
              else

--- a/app/presenters/callback.rb
+++ b/app/presenters/callback.rb
@@ -24,9 +24,9 @@ class Callback
     def to_s
       case @time_slot
       when ['morning']
-        '8am and 12pm'
+        '8am and midday'
       when ['afternoon']
-        '12pm and 5pm'
+        'midday and 5pm'
       when %w[morning afternoon]
         '8am and 5pm'
       else

--- a/app/views/confirmations/_callback.html.haml
+++ b/app/views/confirmations/_callback.html.haml
@@ -11,4 +11,4 @@
   and quote your reference number
   = succeed "." do
     %strong= callback.request_reference
-  We are open Monday to Friday 8am - 7pm and Saturdays 9am - 1pm.
+  We are open Monday to Friday 8am to 7pm and Saturdays 9am to 1pm.

--- a/app/views/pages/address_isnt_here.html.haml
+++ b/app/views/pages/address_isnt_here.html.haml
@@ -12,4 +12,4 @@
   so we can help you with your problem.
 
 %p
-  We are open Monday to Friday 8am - 7pm and Saturdays 9am - 1pm.
+  We are open Monday to Friday 8am to 7pm and Saturdays 9am to 1pm.

--- a/app/views/pages/emergency_contact.html.haml
+++ b/app/views/pages/emergency_contact.html.haml
@@ -16,7 +16,7 @@
     = succeed ',' do
       %span{ itemprop: 'telephone' }
         %a{ href: 'tel:02083562300' } 020 8356 2300
-    Monday - Friday, 8am - 7pm and Saturday, 9am - 1pm
+    Monday to Friday, 8am to 7pm and Saturday, 9am to 1pm
 
 %p
   Outside of these hours, we provide a

--- a/app/views/pages/heating_repairs.html.haml
+++ b/app/views/pages/heating_repairs.html.haml
@@ -17,5 +17,5 @@
   Please call the repairs contact centre on
   %strong
     020 8356 2300
-  Monday&ndash;Friday 8am&ndash;7pm and
-  Saturday 9am&ndash;1pm.
+  Monday to Friday 8am to 7pm and
+  Saturday 9am to 1pm.

--- a/app/views/pages/home_adaptations.html.haml
+++ b/app/views/pages/home_adaptations.html.haml
@@ -13,6 +13,6 @@
   Please call the repairs contact centre on
   %strong
     020 8356 2300
-  Monday&ndash;Friday 8am&ndash;7pm and
-  Saturday 9am&ndash;1pm.
+  Monday to Friday 8am to 7pm and
+  Saturday 9am to 1pm.
 

--- a/app/views/pages/smoke_detector.html.haml
+++ b/app/views/pages/smoke_detector.html.haml
@@ -15,7 +15,7 @@
     = succeed ',' do
       %span{ itemprop: 'telephone' }
         %a{ href: 'tel:02083562300' } 020 8356 2300
-    Monday - Friday, 8am - 7pm and Saturday, 9am - 1pm
+    Monday to Friday, 8am to 7pm and Saturday, 9am to 1pm
 
 %p
   Outside of these hours, we provide a

--- a/app/views/pages/start.html.haml
+++ b/app/views/pages/start.html.haml
@@ -45,10 +45,10 @@
 %p
   They are open
   %strong
-    Monday&ndash;Friday, 8am&ndash;7pm
+    Monday to Friday 8am to 7pm
   and
   %strong
-    Saturday, 9am&ndash;1pm
+    Saturday 9am to 1pm
 
 %h2
   Home improvements

--- a/app/views/pages/toilet_unblock_info.html.haml
+++ b/app/views/pages/toilet_unblock_info.html.haml
@@ -17,5 +17,5 @@
   Please call the repairs contact centre on
   %strong
     020 8356 2300
-  Monday&ndash;Friday 8am&ndash;7pm and
-  Saturday 9am&ndash;1pm.
+  Monday to Friday 8am to 7pm and
+  Saturday 9am to 1pm.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,8 +53,8 @@ en:
           address_isnt_here: "My address isn't here"
       contact_details_form:
         callback_time:
-          morning: "morning (8am - midday)"
-          afternoon: "afternoon (midday - 5pm)"
+          morning: "morning (8am to midday)"
+          afternoon: "afternoon (midday to 5pm)"
       start_form:
         answer:
           smell_gas: I can smell gas

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,8 +53,8 @@ en:
           address_isnt_here: "My address isn't here"
       contact_details_form:
         callback_time:
-          morning: "morning (8am - 12pm)"
-          afternoon: "afternoon (12pm - 5pm)"
+          morning: "morning (8am - midday)"
+          afternoon: "afternoon (midday - 5pm)"
       start_form:
         answer:
           smell_gas: I can smell gas

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     click_on 'Continue'
 
     # Appointments:
-    choose_radio_button 'Wednesday midday-5pm (11th October)'
+    choose_radio_button 'Wednesday midday to 5pm (11th October)'
     click_on 'Continue'
 
     aggregate_failures do
@@ -262,8 +262,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     # Contact details - last page before confirmation:
     fill_in 'Full name', with: 'John Evans'
     fill_in 'Telephone number', with: '078 98765 432'
-    check 'morning (8am - midday)'
-    check 'afternoon (midday - 5pm)'
+    check 'morning (8am to midday)'
+    check 'afternoon (midday to 5pm)'
     click_on 'Continue'
 
     aggregate_failures do
@@ -363,7 +363,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     # Contact details - last page before confirmation:
     fill_in 'Full name', with: 'John Evans'
     fill_in 'Telephone number', with: '078 98765 432'
-    check 'morning (8am - midday)'
+    check 'morning (8am to midday)'
     click_on 'Continue'
 
     aggregate_failures do

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -136,14 +136,14 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     click_on 'Continue'
 
     # Appointments:
-    choose_radio_button 'Wednesday 12pm-5pm (11th October)'
+    choose_radio_button 'Wednesday midday-5pm (11th October)'
     click_on 'Continue'
 
     aggregate_failures do
       within '#confirmation' do
         expect(page).to have_content 'Your reference number is 09124578'
         expect(page).to have_content 'Wednesday 11th October'
-        expect(page).to have_content 'between 12pm and 5pm'
+        expect(page).to have_content 'between midday and 5pm'
       end
 
       within '#summary' do
@@ -262,8 +262,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     # Contact details - last page before confirmation:
     fill_in 'Full name', with: 'John Evans'
     fill_in 'Telephone number', with: '078 98765 432'
-    check 'morning (8am - 12pm)'
-    check 'afternoon (12pm - 5pm)'
+    check 'morning (8am - midday)'
+    check 'afternoon (midday - 5pm)'
     click_on 'Continue'
 
     aggregate_failures do
@@ -308,7 +308,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
-        'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
+        'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and midday",
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
@@ -316,7 +316,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
-        'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
+        'problem' => "The streetlamp is broken\n\nCallback requested: between 8am and midday",
         'propertyReference' => '00000503',
       )
     allow(JsonApi).to receive(:new).and_return(fake_api)
@@ -363,13 +363,13 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     # Contact details - last page before confirmation:
     fill_in 'Full name', with: 'John Evans'
     fill_in 'Telephone number', with: '078 98765 432'
-    check 'morning (8am - 12pm)'
+    check 'morning (8am - midday)'
     click_on 'Continue'
 
     aggregate_failures do
       within '#confirmation' do
         expect(page).to have_content 'Your reference number is 00367923'
-        expect(page).to have_content 'between 8am and 12pm'
+        expect(page).to have_content 'between 8am and midday'
       end
 
       within '#summary' do
@@ -385,7 +385,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'v1/repairs',
       priority: 'N',
-      problemDescription: "The streetlamp is broken\n\nCallback requested: between 8am and 12pm",
+      problemDescription: "The streetlamp is broken\n\nCallback requested: between 8am and midday",
       propertyReference: '00000503',
       contact: {
         name: 'John Evans',

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe RepairParams do
             'callback_time' => ['morning'],
           },
         }
-        expect(RepairParams.new(answers).problem_description).to eq "My bath is broken\n\nCallback requested: between 8am and 12pm"
+
+        expect(RepairParams.new(answers).problem_description)
+          .to eq "My bath is broken\n\nCallback requested: between 8am and midday"
       end
 
       it 'includes the callback info if there was no description' do
@@ -73,7 +75,9 @@ RSpec.describe RepairParams do
             'callback_time' => ['morning'],
           },
         }
-        expect(RepairParams.new(answers).problem_description).to eq "No description given\n\nCallback requested: between 8am and 12pm"
+
+        expect(RepairParams.new(answers).problem_description)
+          .to eq "No description given\n\nCallback requested: between 8am and midday"
       end
     end
   end

--- a/spec/presenters/appointment_presenter_spec.rb
+++ b/spec/presenters/appointment_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AppointmentPresenter do
         'bestSlot' => true
       )
 
-      expect(presenter.description).to eql 'Monday 12:15pm-4:45pm (25th December)'
+      expect(presenter.description).to eql 'Monday 12:15pm to 4:45pm (25th December)'
     end
 
     it 'returns times on the hour without :00' do
@@ -35,7 +35,7 @@ RSpec.describe AppointmentPresenter do
         'bestSlot' => true
       )
 
-      expect(presenter.description).to eql 'Monday 1pm-4pm (25th December)'
+      expect(presenter.description).to eql 'Monday 1pm to 4pm (25th December)'
     end
   end
 

--- a/spec/presenters/appointment_presenter_spec.rb
+++ b/spec/presenters/appointment_presenter_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe AppointmentPresenter do
         'bestSlot' => true
       )
 
-      expect(presenter.time).to eql '12pm and 4:45pm'
+      expect(presenter.time).to eql 'midday and 4:45pm'
     end
   end
 end

--- a/spec/presenters/callback_spec.rb
+++ b/spec/presenters/callback_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Callback do
     context 'when the stored callback time was morning' do
       it 'returns a user-readable string based on the stored callback time' do
         expect(Callback.new(time_slot: ['morning'], request_reference: '00000000').time)
-          .to eq '8am and 12pm'
+          .to eq '8am and midday'
       end
     end
 
     context 'when the stored callback time was afternoon' do
       it 'returns a user-readable string based on the stored callback time' do
         expect(Callback.new(time_slot: ['afternoon'], request_reference: '00000000').time)
-          .to eq '12pm and 5pm'
+          .to eq 'midday and 5pm'
       end
     end
 


### PR DESCRIPTION
As per the gov.uk style guide:
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times

Also use 'to' instead of dashes in time ranges