### PR TITLE
(230) Rails app fixes for appointments endpoints

### DIFF
--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -21,9 +21,10 @@ class HackneyApi
   end
 
   def list_available_appointments(work_order_reference:)
-    @json_api.get(
+    response = @json_api.get(
       'work_orders/' + work_order_reference + '/available_appointments'
     )
+    response.fetch('results')
   end
 
   def book_appointment(work_order_reference:, begin_date:, end_date:)

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -22,14 +22,14 @@ class HackneyApi
 
   def list_available_appointments(work_order_reference:)
     response = @json_api.get(
-      'work_orders/' + work_order_reference + '/available_appointments'
+      'v1/work_orders/' + work_order_reference + '/available_appointments'
     )
     response.fetch('results')
   end
 
   def book_appointment(work_order_reference:, begin_date:, end_date:)
     @json_api.post(
-      'work_orders/' + work_order_reference + '/appointments',
+      'v1/work_orders/' + work_order_reference + '/appointments',
       beginDate: begin_date,
       endDate: end_date
     )

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -22,7 +22,7 @@ class HackneyApi
 
   def list_available_appointments(work_order_reference:)
     @json_api.get(
-      'work_orders/' + work_order_reference + '/appointments'
+      'work_orders/' + work_order_reference + '/available_appointments'
     )
   end
 

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         ]
       )
     allow(fake_api).to receive(:get)
-      .with('work_orders/09124578/available_appointments')
+      .with('v1/work_orders/09124578/available_appointments')
       .and_return(
         'results' => [
           { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
@@ -48,7 +48,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       )
     allow(fake_api).to receive(:post)
       .with(
-        'work_orders/09124578/appointments',
+        'v1/work_orders/09124578/appointments',
         beginDate: '2017-10-11T12:00:00Z',
         endDate: '2017-10-11T17:00:00Z',
       )
@@ -171,7 +171,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     )
 
     expect(fake_api).to have_received(:post).with(
-      'work_orders/09124578/appointments',
+      'v1/work_orders/09124578/appointments',
       beginDate: '2017-10-11T12:00:00Z',
       endDate: '2017-10-11T17:00:00Z',
     )

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         ]
       )
     allow(fake_api).to receive(:get)
-      .with('work_orders/09124578/appointments')
+      .with('work_orders/09124578/available_appointments')
       .and_return(
         [
           { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     allow(fake_api).to receive(:get)
       .with('work_orders/09124578/available_appointments')
       .and_return(
-        [
+        'results' => [
           { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
           { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
         ]

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -112,7 +112,7 @@ describe HackneyApi do
       ]
 
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:get).with('work_orders/00412371/appointments').and_return(result)
+      allow(json_api).to receive(:get).with('work_orders/00412371/available_appointments').and_return(result)
       api = HackneyApi.new(json_api)
 
       expect(api.list_available_appointments(work_order_reference: '00412371')).to eql result

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -125,7 +125,6 @@ describe HackneyApi do
       result = {
         'beginDate' => '2017-11-01T14:00:00Z',
         'endDate' => '2017-11-01T16:30:00Z',
-        'status' => 'booked',
       }
 
       json_api = instance_double('JsonApi')

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -98,7 +98,7 @@ describe HackneyApi do
 
   describe '#list_available_appointments' do
     it 'returns a list of available appointments for a work order' do
-      result = [
+      appointments = [
         {
           'beginDate' => '2017-11-01T08:00:00Z',
           'endDate' => '2017-11-01T12:00:00Z',
@@ -112,10 +112,11 @@ describe HackneyApi do
       ]
 
       json_api = instance_double('JsonApi')
+      result = { 'results' => appointments }
       allow(json_api).to receive(:get).with('work_orders/00412371/available_appointments').and_return(result)
       api = HackneyApi.new(json_api)
 
-      expect(api.list_available_appointments(work_order_reference: '00412371')).to eql result
+      expect(api.list_available_appointments(work_order_reference: '00412371')).to eql appointments
     end
   end
 

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -113,7 +113,7 @@ describe HackneyApi do
 
       json_api = instance_double('JsonApi')
       result = { 'results' => appointments }
-      allow(json_api).to receive(:get).with('work_orders/00412371/available_appointments').and_return(result)
+      allow(json_api).to receive(:get).with('v1/work_orders/00412371/available_appointments').and_return(result)
       api = HackneyApi.new(json_api)
 
       expect(api.list_available_appointments(work_order_reference: '00412371')).to eql appointments
@@ -132,7 +132,7 @@ describe HackneyApi do
       allow(json_api)
         .to receive(:post)
         .with(
-          'work_orders/00412371/appointments',
+          'v1/work_orders/00412371/appointments',
           beginDate: '2017-11-01T14:00:00Z',
           endDate: '2017-11-01T16:30:00Z'
         )


### PR DESCRIPTION
**NB: This is based off #216, which should be merged first**

  - Fetching a list of appointments is now done via `GET /v1/work_orders/:workOrderReference/available_appointments`. The response is wrapped in a `results` attribute.
  - After booking an appointment, the response no longer contains the `status` attribute, because this doesn't actually get returned by DRS.