### PR TITLE
(235) Rationalise all phone numbers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
 
   def telephone_number(number)
     tag.span itemprop: 'telephone' do
-      link_to number, "tel:#{number.gsub!(/\s+/, '')}"
+      link_to number, "tel:#{number.gsub(/\s+/, '')}"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,35 @@ module ApplicationHelper
   def back_link
     tag.span class: 'js-back-link', data: { text: t('back_link') }
   end
+
+  def telephone_number(number)
+    tag.span itemprop: 'telephone' do
+      link_to number, "tel:#{number.gsub!(/\s+/, '')}"
+    end
+  end
+
+  def repairs_contact_centre_telephone_number
+    telephone_number('020 8356 3691')
+  end
+
+  def repairs_emergency_telephone_number
+    # NOTE: This is the same as the main RCC number
+    # but redirects to another number out of hours
+    telephone_number('020 8356 3691')
+  end
+
+  def gas_emergency_telephone_number
+    telephone_number('0800 111 999')
+  end
+
+  def electricity_emergency_telephone_number
+    # TODO: this is the 'temporary emergency number'
+    # should possibly be the national power network
+    # number instead? '0800 028 0247'
+    telephone_number('020 8356 2300')
+  end
+
+  def water_emergency_telephone_number
+    telephone_number('0800 714 614')
+  end
 end

--- a/app/views/confirmations/_callback.html.haml
+++ b/app/views/confirmations/_callback.html.haml
@@ -6,8 +6,7 @@
 %p
   %strong
     If you have any questions, please call us on
-    %span{:itemprop => "telephone"}
-      = link_to "020 8356 3691", "tel:+02083563691"
+    = repairs_contact_centre_telephone_number
   and quote your reference number
   = succeed "." do
     %strong= callback.request_reference

--- a/app/views/errors/service_disabled.html.haml
+++ b/app/views/errors/service_disabled.html.haml
@@ -5,16 +5,14 @@
   %strong
     Please phone our repairs contact centre on
     = succeed '.' do
-      %span{ itemprop: 'telephone' }
-        %a{ href: 'tel:02083563691' } 020 8356 3691
+      = repairs_contact_centre_telephone_number
     We’re open Monday to Friday from 8am to midnight and on Saturday
     from 9am to 1pm.
 
 %p
   If you have an emergency repair outside of these hours, you should phone us on
   = succeed '.' do
-    %span{ itemprop: 'telephone' }
-      %a{ href: 'tel:02083563691' } 020 8356 3691
+    = repairs_emergency_telephone_number
 
 %p
   Emergency repairs include:
@@ -37,14 +35,11 @@
 
 %p
   Electricity:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:08000280247' } 0800 028 0247
+  = electricity_emergency_telephone_number
   %br/
   Gas:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:0800111999' } 0800 111 999
+  = gas_emergency_telephone_number
   %br/
   Water:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:0800714614' } 0800 714 614
+  = water_emergency_telephone_number
   %br/

--- a/app/views/pages/_emergency_telephone_numbers.html.haml
+++ b/app/views/pages/_emergency_telephone_numbers.html.haml
@@ -1,0 +1,30 @@
+%p
+  %strong
+    Call us on:
+    = succeed ',' do
+      = repairs_contact_centre_telephone_number
+    Monday to Friday, 8am to 7pm and Saturday, 9am to 1pm
+
+%p
+  Outside of these hours, we provide a
+  %em
+    make safe
+  service, to ensure that there is no danger to your household or significant
+  damage to your property, please call:
+  %strong
+    = repairs_emergency_telephone_number
+
+%p
+  %strong
+    For electricity:
+  = electricity_emergency_telephone_number
+
+%p
+  %strong
+    For water:
+  = water_emergency_telephone_number
+
+%p
+  %strong
+    For gas:
+  = gas_emergency_telephone_number

--- a/app/views/pages/address_isnt_here.html.haml
+++ b/app/views/pages/address_isnt_here.html.haml
@@ -8,7 +8,7 @@
 
 %p
   If you are one of our tenants, please call our repair centre on
-  %a{ href: 'tel:02083563691' } 020 8356 3691
+  = repairs_contact_centre_telephone_number
   so we can help you with your problem.
 
 %p

--- a/app/views/pages/carbon_monoxide_alarm.html.haml
+++ b/app/views/pages/carbon_monoxide_alarm.html.haml
@@ -21,6 +21,5 @@
     Open doors and windows to ventilate the area
   %li
     Contact National Grid on
-    %strong
-      0800 111 999
+    %strong= gas_emergency_telephone_number
     from outside the property

--- a/app/views/pages/check_fusebox.html.haml
+++ b/app/views/pages/check_fusebox.html.haml
@@ -11,7 +11,9 @@
 %p
   The fuse box is typically located in the hallway cupboard. If you would
   like help locating the fuse box in your home, please call the repairs
-  contact centre on 020 8356 2300.
+  contact centre on
+  = succeed '.' do
+    = electricity_emergency_telephone_number
 
 %p
   %strong

--- a/app/views/pages/electrical_hazard_warning.html.haml
+++ b/app/views/pages/electrical_hazard_warning.html.haml
@@ -11,7 +11,9 @@
 %p
   If you are uncertain or have any immediate concerns about an electrical
   repair issue in your home, please call our repairs contact centre for
-  guidance on 020 8356 2300.
+  guidance on
+  = succeed '.'
+    = electricity_emergency_telephone_number
 
 %p
   If you would like to book an appointment for your electrical repair,

--- a/app/views/pages/emergency_contact.html.haml
+++ b/app/views/pages/emergency_contact.html.haml
@@ -10,38 +10,4 @@
   We ask that you report Emergency and Immediate repair problems through our Repairs Contact Centre.
   This will allow us to review your repair straight away and schedule a suitable appointment to help resolve the issue quickly.
 
-%p
-  %strong
-    Call us on:
-    = succeed ',' do
-      %span{ itemprop: 'telephone' }
-        %a{ href: 'tel:02083562300' } 020 8356 2300
-    Monday to Friday, 8am to 7pm and Saturday, 9am to 1pm
-
-%p
-  Outside of these hours, we provide a
-  %em
-    make safe
-  service, to ensure that there is no danger to your household or significant
-  damage to your property, please call:
-  %strong
-    %span{ itemprop: 'telephone' }
-      %a{ href: 'tel:02083562300' }020 8356 2300
-
-%p
-  %strong
-    For electricity:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:08000280247' } 020 8356 2300
-
-%p
-  %strong
-    For water:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:0800714614' } 0800 714 614
-
-%p
-  %strong
-    For gas:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:0800111999' } 0800 111 999
+= render partial: 'pages/emergency_telephone_numbers'

--- a/app/views/pages/gas.html.haml
+++ b/app/views/pages/gas.html.haml
@@ -18,6 +18,5 @@
     Open doors and windows to ventilate the area
   %li
     Contact National Grid on
-    %strong
-      0800 111 999
+    %strong= gas_emergency_telephone_number
     from outside the property

--- a/app/views/pages/heating_repairs.html.haml
+++ b/app/views/pages/heating_repairs.html.haml
@@ -15,7 +15,6 @@
 
 %p
   Please call the repairs contact centre on
-  %strong
-    020 8356 2300
+  %strong= repairs_contact_centre_telephone_number
   Monday to Friday 8am to 7pm and
   Saturday 9am to 1pm.

--- a/app/views/pages/home_adaptations.html.haml
+++ b/app/views/pages/home_adaptations.html.haml
@@ -11,8 +11,7 @@
 
 %p
   Please call the repairs contact centre on
-  %strong
-    020 8356 2300
+  %strong= repairs_contact_centre_telephone_number
   Monday to Friday 8am to 7pm and
   Saturday 9am to 1pm.
 

--- a/app/views/pages/smoke_detector.html.haml
+++ b/app/views/pages/smoke_detector.html.haml
@@ -9,38 +9,4 @@
   as a priority and schedule a suitable appointment to help
   resolve the issue quickly.
 
-%p
-  %strong
-    Call us on:
-    = succeed ',' do
-      %span{ itemprop: 'telephone' }
-        %a{ href: 'tel:02083562300' } 020 8356 2300
-    Monday to Friday, 8am to 7pm and Saturday, 9am to 1pm
-
-%p
-  Outside of these hours, we provide a
-  %em
-    make safe
-  service, to ensure that there is no danger to your household or significant
-  damage to your property, please call:
-  %strong
-    %span{ itemprop: 'telephone' }
-      %a{ href: 'tel:02083562300' } 020 8356 2300
-
-%p
-  %strong
-    For electricity:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:08000280247' } 020 8356 2300
-
-%p
-  %strong
-    For water:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:0800714614' } 0800 714 614
-
-%p
-  %strong
-    For gas, call National Grid:
-  %span{ itemprop: 'telephone' }
-    %a{ href: 'tel:0800111999' } 0800 111 999
+= render partial: 'emergency_telephone_numbers'

--- a/app/views/pages/start.html.haml
+++ b/app/views/pages/start.html.haml
@@ -25,9 +25,7 @@
   %strong
     If you can smell gas, please call National Gas Emergency on:
     %br/
-    %span{ itemprop: 'telephone' }
-      %a{ href: 'tel:0800111999' }
-        0800 111 999
+    = gas_emergency_telephone_number
 
 %p
   %a.button.button-start{ href: '/questions/start/' } Start
@@ -38,9 +36,8 @@
 %p
   If your repair is an emergency, please call the
   Repairs Contact Centre on
-  %span{ itemprop: 'telephone' }
-    = succeed '.' do
-      %a{ href: 'tel:02083563691' } 020 8356 3691
+  = succeed '.' do
+    = repairs_contact_centre_telephone_number
 
 %p
   They are open

--- a/app/views/pages/style_guide.html.haml
+++ b/app/views/pages/style_guide.html.haml
@@ -31,7 +31,7 @@
 
   %strong
     If you smell gas, please call National Gas Emergency on
-    %a{ href: 'tel:0800111999' } 0800 111 999
+    = gas_emergency_telephone_number
     for assistance.
 
 %ul

--- a/app/views/pages/toilet_unblock_info.html.haml
+++ b/app/views/pages/toilet_unblock_info.html.haml
@@ -15,7 +15,6 @@
 
 %p
   Please call the repairs contact centre on
-  %strong
-    020 8356 2300
+  %strong= repairs_contact_centre_telephone_number
   Monday to Friday 8am to 7pm and
   Saturday 9am to 1pm.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#telephone_number' do
+    it 'wraps the phone number in appropriate markup' do
+      expect(helper.telephone_number('01234 567 890'))
+        .to eq(%(<span itemprop="telephone"><a href="tel:01234567890">01234567890</a></span>))
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationHelper do
   describe '#telephone_number' do
     it 'wraps the phone number in appropriate markup' do
       expect(helper.telephone_number('01234 567 890'))
-        .to eq(%(<span itemprop="telephone"><a href="tel:01234567890">01234567890</a></span>))
+        .to eq(%(<span itemprop="telephone"><a href="tel:01234567890">01234 567 890</a></span>))
     end
   end
 end


### PR DESCRIPTION
There are a lot of pages in the site which include phone numbers. In some
 cases the numbers were inconsistent, and how they were presented on the
 page was inconsistent as well.

 Now there is only one place where phone numbers are explicitly written, and
 everywhere they are used in the pages they are used in the same way: as a
 telephone number link with the appropriate 'itemprop'.

 Note that in some places the specific number used on a page has been
 corrected to the most appropriate one.