### PR TITLE
(208) User facing validation

### DIFF
--- a/app/assets/javascripts/character_limit.js
+++ b/app/assets/javascripts/character_limit.js
@@ -1,0 +1,37 @@
+$(document).ready(function(){
+  $('textarea').each(function() {
+    var textArea = $(this);
+
+    var limitElement = $("<div>",
+      {
+        "class" : "character-limit",
+        "aria-live" : "polite"
+      }
+    );
+
+    textArea.parent().append(limitElement);
+
+    function updateRemaining() {
+      var limit = textArea.attr('maxlength');
+      var used = textArea.val().length;
+
+      var remaining = limit - used;
+
+      if (remaining == 1) {
+        remainingText = "1 character remaining";
+      } else {
+        remainingText = remaining + " characters remaining";
+      }
+
+      limitElement.text(remainingText);
+    }
+
+    if (textArea.attr('maxlength')) {
+      textArea.keyup(function() {
+        updateRemaining();
+      });
+
+      updateRemaining();
+    }
+  });
+});

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -40,3 +40,8 @@ input.string {
 ul.error-summary-list {
   list-style-type: none;
 }
+
+.character-limit {
+  margin-top: 0.5em;
+  text-align: right;
+}

--- a/app/models/contact_details_form.rb
+++ b/app/models/contact_details_form.rb
@@ -6,8 +6,24 @@ class ContactDetailsForm
   validates :full_name, presence: true, length: { minimum: 2 }
   validates :telephone_number, presence: true
 
+  validate :telephone_number_format
+
   def initialize(hash = {})
     @full_name = hash[:full_name]
     @telephone_number = hash[:telephone_number]
+  end
+
+  private
+
+  def telephone_number_format
+    return unless telephone_number
+
+    telephone_number_only_digits = telephone_number.gsub(/\D/, '')
+
+    if telephone_number_only_digits.size < 10
+      errors.add(:telephone_number, :too_short, count: 10)
+    elsif telephone_number_only_digits.size > 11
+      errors.add(:telephone_number, :too_long, count: 11)
+    end
   end
 end

--- a/app/models/contact_details_form.rb
+++ b/app/models/contact_details_form.rb
@@ -3,7 +3,8 @@ class ContactDetailsForm
 
   attr_reader :full_name, :telephone_number
 
-  validates :full_name, :telephone_number, presence: true
+  validates :full_name, presence: true, length: { minimum: 2 }
+  validates :telephone_number, presence: true
 
   def initialize(hash = {})
     @full_name = hash[:full_name]

--- a/app/models/describe_repair_form.rb
+++ b/app/models/describe_repair_form.rb
@@ -2,4 +2,6 @@ class DescribeRepairForm
   include ActiveModel::Model
 
   attr_accessor :description
+
+  validates :description, length: { maximum: 500 }
 end

--- a/app/models/describe_unknown_repair_form.rb
+++ b/app/models/describe_unknown_repair_form.rb
@@ -3,7 +3,7 @@ class DescribeUnknownRepairForm
 
   attr_reader :description
 
-  validates :description, presence: true
+  validates :description, presence: true, length: { maximum: 500 }
 
   def initialize(hash = {})
     @description = hash[:description]

--- a/app/views/describe_repair/index.html.haml
+++ b/app/views/describe_repair/index.html.haml
@@ -6,5 +6,5 @@
       = render partial: @describe_repair.partial
 
     .answers
-      = f.input :description, as: :text
+      = f.input :description, as: :text, input_html: { maxlength: 500 }
       = f.button :submit, class: 'button'

--- a/spec/features/users_can_describe_their_repair_spec.rb
+++ b/spec/features/users_can_describe_their_repair_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.feature 'Users can describe their repair' do
+  feature 'users are shown the number of characters they can enter', js: true do
+    scenario 'when the page first loads' do
+      visit '/describe-repair'
+
+      expect(page).to have_content '500 characters remaining'
+    end
+
+    scenario 'whilst entering text' do
+      visit '/describe-repair'
+
+      element = find('textarea#describe_repair_form_description')
+
+      element.send_keys 'h'
+      expect(page).to have_content '499 characters remaining'
+
+      element.send_keys 'i'
+      expect(page).to have_content '498 characters remaining'
+    end
+
+    scenario 'when reaching the limit of the textarea' do
+      visit '/describe-repair'
+
+      fill_in 'Problem description', with: 'X' * 500
+      expect(page).to have_content '0 characters remaining'
+
+      element = find('textarea#describe_repair_form_description')
+      element.send_keys '*'
+
+      expect(page).to have_content '0 characters remaining'
+    end
+  end
+end

--- a/spec/models/contact_details_form_spec.rb
+++ b/spec/models/contact_details_form_spec.rb
@@ -11,25 +11,50 @@ RSpec.describe ContactDetailsForm do
       expect(form).to be_valid
     end
 
-    it 'is invalid when full_name is blank' do
-      form = ContactDetailsForm.new
-      form.valid?
+    describe '.full_name' do
+      it 'is invalid when blank' do
+        form = ContactDetailsForm.new
+        form.valid?
 
-      expect(form.errors.details[:full_name]).to include(error: :blank)
+        expect(form.errors.details[:full_name]).to include(error: :blank)
+      end
+
+      it 'is invalid when less than 2 characters long' do
+        form = ContactDetailsForm.new(full_name: 'x')
+        form.valid?
+
+        expect(form.errors.details[:full_name]).to include(error: :too_short, count: 2)
+      end
     end
 
-    it 'is invalid when full_name is less than 2 characters long' do
-      form = ContactDetailsForm.new(full_name: 'x')
-      form.valid?
+    describe '.telephone_number' do
+      it 'is invalid when blank' do
+        form = ContactDetailsForm.new
+        form.valid?
 
-      expect(form.errors.details[:full_name]).to include(error: :too_short, count: 2)
-    end
+        expect(form.errors.details[:telephone_number]).to include(error: :blank)
+      end
 
-    it 'is invalid when telephone_number is blank' do
-      form = ContactDetailsForm.new
-      form.valid?
+      it 'is invalid when too short' do
+        form = ContactDetailsForm.new(telephone_number: '012345678')
+        form.valid?
 
-      expect(form.errors.details[:telephone_number]).to include(error: :blank)
+        expect(form.errors.details[:telephone_number]).to include(error: :too_short, count: 10)
+      end
+
+      it 'is invalid when too long' do
+        form = ContactDetailsForm.new(telephone_number: '079001234560')
+        form.valid?
+
+        expect(form.errors.details[:telephone_number]).to include(error: :too_long, count: 11)
+      end
+
+      it 'only counts digits towards the length limit' do
+        form = ContactDetailsForm.new(telephone_number: ' (01234) 567890    ')
+        form.valid?
+
+        expect(form.errors.details[:telephone_number]).to be_empty
+      end
     end
   end
 end

--- a/spec/models/contact_details_form_spec.rb
+++ b/spec/models/contact_details_form_spec.rb
@@ -2,20 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ContactDetailsForm do
   describe 'validations' do
-    it 'is invalid when full_name is blank' do
-      form = ContactDetailsForm.new
-      form.valid?
-
-      expect(form.errors.details[:full_name]).to include(error: :blank)
-    end
-
-    it 'is invalid when telephone_number is blank' do
-      form = ContactDetailsForm.new
-      form.valid?
-
-      expect(form.errors.details[:telephone_number]).to include(error: :blank)
-    end
-
     it 'is valid when the required parameters are provided' do
       form = ContactDetailsForm.new(
         full_name: 'Robin Hood',
@@ -23,6 +9,27 @@ RSpec.describe ContactDetailsForm do
       )
 
       expect(form).to be_valid
+    end
+
+    it 'is invalid when full_name is blank' do
+      form = ContactDetailsForm.new
+      form.valid?
+
+      expect(form.errors.details[:full_name]).to include(error: :blank)
+    end
+
+    it 'is invalid when full_name is less than 2 characters long' do
+      form = ContactDetailsForm.new(full_name: 'x')
+      form.valid?
+
+      expect(form.errors.details[:full_name]).to include(error: :too_short, count: 2)
+    end
+
+    it 'is invalid when telephone_number is blank' do
+      form = ContactDetailsForm.new
+      form.valid?
+
+      expect(form.errors.details[:telephone_number]).to include(error: :blank)
     end
   end
 end

--- a/spec/models/contact_details_with_callback.form_spec.rb
+++ b/spec/models/contact_details_with_callback.form_spec.rb
@@ -2,6 +2,16 @@ require 'rails_helper'
 
 RSpec.describe ContactDetailsWithCallbackForm do
   describe 'validations' do
+    it 'is valid when the required parameters are provided' do
+      form = ContactDetailsWithCallbackForm.new(
+        full_name: 'Robin Hood',
+        telephone_number: '0115 123 4567',
+        callback_time: :afternoon
+      )
+
+      expect(form).to be_valid
+    end
+
     it 'is invalid when full_name is blank' do
       form = ContactDetailsWithCallbackForm.new
       form.valid?
@@ -21,16 +31,6 @@ RSpec.describe ContactDetailsWithCallbackForm do
       form.valid?
 
       expect(form.errors.details[:callback_time]).to include(error: :blank)
-    end
-
-    it 'is valid when the required parameters are provided' do
-      form = ContactDetailsWithCallbackForm.new(
-        full_name: 'Robin Hood',
-        telephone_number: '0115 123 4567',
-        callback_time: :afternoon
-      )
-
-      expect(form).to be_valid
     end
   end
 end

--- a/spec/models/describe_repair_form_spec.rb
+++ b/spec/models/describe_repair_form_spec.rb
@@ -13,5 +13,13 @@ RSpec.describe DescribeRepairForm do
       form = DescribeRepairForm.new(description: 'my taps are leaking')
       expect(form).to be_valid
     end
+
+    it 'is invalid with an overly long description' do
+      form = DescribeRepairForm.new(description: ('X' * 501))
+      form.valid?
+
+      expect(form.errors.details[:description])
+        .to include(error: :too_long, count: 500)
+    end
   end
 end

--- a/spec/models/describe_unknown_repair_form.rb
+++ b/spec/models/describe_unknown_repair_form.rb
@@ -2,11 +2,24 @@ require 'rails_helper'
 
 RSpec.describe DescribeUnknownRepairForm do
   describe 'validations' do
-    it '.description' do
+    it 'is valid with a description' do
+      form = DescribeUnknownRepairForm.new(description: 'It is broken')
+
+      expect(form).to be_valid
+    end
+
+    it 'is invalid without a description' do
       form = DescribeUnknownRepairForm.new
       form.valid?
 
       expect(form.errors.details[:description]).to include(error: :blank)
+    end
+
+    it 'is invalid with an overly long description' do
+      form = DescribeUnknownRepairForm.new(description: ('X' * 201))
+      form.valid?
+
+      expect(form.errors.details[:description]).to include(error: :too_long, count: 500)
     end
   end
 end


### PR DESCRIPTION
Add validation in the following places, to ensure that user input won't cause an error from the API.

 - Contact name is at least 2 characters
 - Telephone number is 10-11 digits (spaces and non-numeric values don't count towards this)
 - Limit description to 500 characters, and show "characters remaining" using JavaScript

![character_count](https://user-images.githubusercontent.com/3166/33272672-c0c8cdfa-d382-11e7-880f-091312bd5dd3.png)


