### PR TITLE
(172) Display friendly messages when api fails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,8 @@ class ApplicationController < ActionController::Base
   def check_service_status
     raise ServiceDisabled if App.flipper.enabled?(:service_disabled)
   end
+
+  rescue_from JsonApi::ApiError do
+    render 'errors/api_error'
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,11 @@ class ApplicationController < ActionController::Base
     render 'errors/service_disabled'
   end
 
+  rescue_from JsonApi::ApiError do |e|
+    logger.error "[Handled] #{e.class}: #{e.message}"
+    render 'errors/api_error'
+  end
+
   include Authentication
 
   def selected_answer_store
@@ -21,9 +26,5 @@ class ApplicationController < ActionController::Base
 
   def check_service_status
     raise ServiceDisabled if App.flipper.enabled?(:service_disabled)
-  end
-
-  rescue_from JsonApi::ApiError do
-    render 'errors/api_error'
   end
 end

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -1,13 +1,16 @@
 class JsonApi
   class Error < StandardError; end
+
   class InvalidApiRootError < Error; end
   class MissingPrivateKeyError < Error; end
-  class InvalidResponseError < Error; end
-  class ConnectionError < Error; end
-  class StatusBadRequestError < Error; end
-  class StatusNotFoundError < Error; end
-  class StatusServerError < Error; end
-  class StatusUnexpectedError < Error; end
+
+  class ApiError < Error; end
+  class InvalidResponseError < ApiError; end
+  class ConnectionError < ApiError; end
+  class StatusBadRequestError < ApiError; end
+  class StatusNotFoundError < ApiError; end
+  class StatusServerError < ApiError; end
+  class StatusUnexpectedError < ApiError; end
 
   def initialize(api_config = {})
     @connection = ConnectionBuilder.new.build(api_config)

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -62,7 +62,14 @@ class JsonApi
   end
 
   def error_message(response)
-    response.body&.dig('errors', 'developerMessage')
+    case response.body
+    when Array
+      response.body
+              .map { |error| error.fetch('developerMessage', '') }
+              .join(', ')
+    when Hash
+      response.body.dig('errors', 'developerMessage')
+    end
   end
 
   class ConnectionBuilder

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -10,19 +10,26 @@ class JsonApi
   end
 
   def get(path)
-    @connection.get(path).body
-  rescue Faraday::ParsingError => e
-    raise InvalidResponseError, e.message
-  rescue Faraday::ConnectionFailed => e
-    raise ConnectionError, e.message
+    response = call_and_raise do
+      @connection.get(path)
+    end
+    response.body
   end
 
   def post(path, params)
-    response = @connection.post(path) do |request|
-      request.body = params.to_json
-      request.headers['Content-Type'] = 'application/json'
+    response = call_and_raise do
+      @connection.post(path) do |request|
+        request.body = params.to_json
+        request.headers['Content-Type'] = 'application/json'
+      end
     end
     response.body
+  end
+
+  private
+
+  def call_and_raise
+    yield
   rescue Faraday::ParsingError => e
     raise InvalidResponseError, e.message
   rescue Faraday::ConnectionFailed => e

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -3,6 +3,7 @@ class JsonApi
   class InvalidApiRootError < Error; end
   class MissingPrivateKeyError < Error; end
   class InvalidResponseError < Error; end
+  class ConnectionError < Error; end
 
   def initialize(api_config = {})
     @connection = ConnectionBuilder.new.build(api_config)
@@ -12,6 +13,8 @@ class JsonApi
     @connection.get(path).body
   rescue Faraday::ParsingError => e
     raise InvalidResponseError, e.message
+  rescue Faraday::ConnectionFailed => e
+    raise ConnectionError, e.message
   end
 
   def post(path, params)
@@ -22,6 +25,8 @@ class JsonApi
     response.body
   rescue Faraday::ParsingError => e
     raise InvalidResponseError, e.message
+  rescue Faraday::ConnectionFailed => e
+    raise ConnectionError, e.message
   end
 
   class ConnectionBuilder

--- a/app/views/errors/_contact_phone_numbers.html.haml
+++ b/app/views/errors/_contact_phone_numbers.html.haml
@@ -1,0 +1,42 @@
+%p
+  %strong
+    Please phone our repairs contact centre on
+    = succeed '.' do
+      = repairs_contact_centre_telephone_number
+    We’re open Monday to Friday from 8am to midnight and on Saturday
+    from 9am to 1pm.
+
+%p
+  If you have an emergency repair outside of these hours, you should phone us on
+  = succeed '.' do
+    = repairs_emergency_telephone_number
+
+%p
+  Emergency repairs include:
+
+%ul
+  %li
+    flood, fire or explosion damage
+  %li
+    access to get back into your property for vulnerable tenants, however we
+    will charge you for doing this
+  %li
+    major plumbing and electrical faults resulting in large scale water loss
+    or power loss
+  %li
+    blocked toilet where it’s your only toilet
+
+%p
+  If your emergency relates to gas, electricity or water supply emergencies,
+  you should phone:
+
+%p
+  Electricity:
+  = electricity_emergency_telephone_number
+  %br/
+  Gas:
+  = gas_emergency_telephone_number
+  %br/
+  Water:
+  = water_emergency_telephone_number
+  %br/

--- a/app/views/errors/api_error.html.haml
+++ b/app/views/errors/api_error.html.haml
@@ -1,0 +1,9 @@
+= back_link
+
+%heading
+  %h1
+    We're really sorry
+  %p
+    We seem to be having some problems communicating with our repairs systems.
+
+= render partial: 'errors/contact_phone_numbers'

--- a/app/views/errors/service_disabled.html.haml
+++ b/app/views/errors/service_disabled.html.haml
@@ -1,45 +1,4 @@
 %h1
   Sorry! This service is temporarily unavailable.
 
-%p
-  %strong
-    Please phone our repairs contact centre on
-    = succeed '.' do
-      = repairs_contact_centre_telephone_number
-    We’re open Monday to Friday from 8am to midnight and on Saturday
-    from 9am to 1pm.
-
-%p
-  If you have an emergency repair outside of these hours, you should phone us on
-  = succeed '.' do
-    = repairs_emergency_telephone_number
-
-%p
-  Emergency repairs include:
-
-%ul
-  %li
-    flood, fire or explosion damage
-  %li
-    access to get back into your property for vulnerable tenants, however we
-    will charge you for doing this
-  %li
-    major plumbing and electrical faults resulting in large scale water loss
-    or power loss
-  %li
-    blocked toilet where it’s your only toilet
-
-%p
-  If your emergency relates to gas, electricity or water supply emergencies,
-  you should phone:
-
-%p
-  Electricity:
-  = electricity_emergency_telephone_number
-  %br/
-  Gas:
-  = gas_emergency_telephone_number
-  %br/
-  Water:
-  = water_emergency_telephone_number
-  %br/
+= render partial: 'errors/contact_phone_numbers'

--- a/spec/features/residents_see_nice_errors_spec.rb
+++ b/spec/features/residents_see_nice_errors_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Error pages' do
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get)
       .with('v1/properties?postcode=E5 8TE')
-      .and_raise JsonApi::ConnectionError
+      .and_raise JsonApi::ConnectionError, 'Failed to open TCP connection to api_server:8000 (getaddrinfo: nodename nor servname provided, or not known)'
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     fake_question_set = instance_double(QuestionSet)
@@ -23,6 +23,8 @@ RSpec.feature 'Error pages' do
         )
       )
     allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+
+    allow(Rails.logger).to receive(:error)
 
     visit '/'
     click_on 'Start'
@@ -44,6 +46,8 @@ RSpec.feature 'Error pages' do
     click_on 'Find my address'
 
     expect(page).to have_content "We're really sorry"
+    expect(Rails.logger).to have_received(:error)
+      .with('[Handled] JsonApi::ConnectionError: Failed to open TCP connection to api_server:8000 (getaddrinfo: nodename nor servname provided, or not known)')
   end
 end
 

--- a/spec/features/residents_see_nice_errors_spec.rb
+++ b/spec/features/residents_see_nice_errors_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.feature 'Error pages' do
+  scenario 'when UH is not available' do
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get)
+      .with('v1/properties?postcode=E5 8TE')
+      .and_raise JsonApi::ConnectionError
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    fake_question_set = instance_double(QuestionSet)
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('location')
+      .and_return(
+        Question.new(
+          'question' => 'Where is the problem?',
+          'answers' => [
+            { 'text' => 'Kitchen' },
+            { 'text' => 'Bathroom' },
+            { 'text' => 'Other' },
+          ],
+        )
+      )
+    allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Kitchen'
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E5 8TE'
+    click_on 'Find my address'
+
+    expect(page).to have_content "We're really sorry"
+  end
+end
+

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe JsonApi do
       expect(result).to eq nil
     end
 
+    it 'raises an error when the connection failed' do
+      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+      stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA').to_timeout
+
+      expect { json_api.get('properties?postcode=A1 1AA') }
+        .to raise_error(JsonApi::ConnectionError)
+    end
+
     context 'when a client certificate is specified' do
       # TODO: work out how to test that the certificate and api_key actually get used
 
@@ -162,6 +170,14 @@ RSpec.describe JsonApi do
         expect { json_api.post('/v1/repairs', {}) }
           .to raise_error(JsonApi::InvalidResponseError, "765: unexpected token at 'not found'")
       end
+    end
+
+    it 'raises an error when the connection failed' do
+      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+      stub_request(:post, 'http://hackney.api:8000/repairs').to_timeout
+
+      expect { json_api.post('/repairs', {}) }
+        .to raise_error(JsonApi::ConnectionError)
     end
   end
 end

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -107,12 +107,66 @@ RSpec.describe JsonApi do
       expect(result).to eq nil
     end
 
-    it 'raises an error when the connection failed' do
-      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-      stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA').to_timeout
+    context 'when the connection failed' do
+      it 'raises an error' do
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA').to_timeout
 
-      expect { json_api.get('properties?postcode=A1 1AA') }
-        .to raise_error(JsonApi::ConnectionError)
+        expect { json_api.get('properties?postcode=A1 1AA') }
+          .to raise_error(JsonApi::ConnectionError)
+      end
+    end
+
+    context 'when the response is a 404 status' do
+      it 'raises an error' do
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+          .to_return(
+            status: 404,
+            body: nil.to_json
+          )
+        expect { json_api.get('properties?postcode=A1 1AA') }
+          .to raise_error(JsonApi::StatusNotFoundError)
+      end
+    end
+
+    context 'when the response is a 400 status' do
+      it 'raises an error' do
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+          .to_return(
+            status: 400,
+            body: { 'errors' => { 'userMessage' => 'That was invalid', 'developerMessage' => 'invalid request' } }.to_json
+          )
+        expect { json_api.get('properties?postcode=A1 1AA') }
+          .to raise_error(JsonApi::StatusBadRequestError, 'invalid request')
+      end
+    end
+
+    context 'when the response is a 500 status' do
+      it 'raises an error' do
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+          .to_return(
+            status: 500,
+            body: { 'errors' => { 'userMessage' => 'Something is wrong', 'developerMessage' => 'server error' } }.to_json
+          )
+        expect { json_api.get('properties?postcode=A1 1AA') }
+          .to raise_error(JsonApi::StatusServerError, 'server error')
+      end
+    end
+
+    context 'when the response is an unexpected status' do
+      it 'raises an error' do
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+          .to_return(
+            status: 503,
+            body: { 'errors' => { 'userMessage' => 'Something is wrong', 'developerMessage' => 'server error' } }.to_json
+          )
+        expect { json_api.get('properties?postcode=A1 1AA') }
+          .to raise_error(JsonApi::StatusUnexpectedError, 'server error')
+      end
     end
 
     context 'when a client certificate is specified' do


### PR DESCRIPTION
- Raise errors for various kinds of failure
- Display a page to the user
- Ensure that these are logged