### PR TITLE
(210) Prevent appointment tampering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ root of the application containing environment variable assignments.
 The following environment variables are required to run the site:
 
 - `HACKNEY_API_ROOT` - the root of the Hackney API which is used by the site
+- `ENCRYPTION_SECRET` - secret used to prevent parameter tampering
 
 ### Optional config
 

--- a/app/models/appointment_form.rb
+++ b/app/models/appointment_form.rb
@@ -1,43 +1,28 @@
 class AppointmentForm
-  class InvalidAppointment < StandardError; end
-
   include ActiveModel::Model
 
   attr_reader :appointment_id
 
   validates :appointment_id, presence: true
 
-  def initialize(hash = {})
-    @appointment_id = hash[:appointment_id]
-
-    validate_appointment_dates!
+  def initialize(hash = {}, verifier: ActiveSupport::MessageVerifier)
+    @appointment_id = hash['appointment_id']
+    @verifier = verifier
   end
 
   def begin_date
-    split_date.first
+    decrypted_appointment.fetch('beginDate')
   end
 
   def end_date
-    split_date.last
+    decrypted_appointment.fetch('endDate')
   end
 
   private
 
-  def split_date
-    @split_date ||= @appointment_id.to_s.split('|')
-  end
-
-  def validate_appointment_dates!
-    return unless @appointment_id
-
-    raise InvalidAppointment unless split_date.size == 2
-
-    split_date.each do |date|
-      begin
-        Time.zone.parse(date)
-      rescue ArgumentError
-        raise InvalidAppointment
-      end
-    end
+  def decrypted_appointment
+    @decrypted_appointment ||= @verifier
+                               .new(ENV.fetch('ENCRYPTION_SECRET'))
+                               .verify(@appointment_id)
   end
 end

--- a/app/presenters/appointment_presenter.rb
+++ b/app/presenters/appointment_presenter.rb
@@ -1,15 +1,15 @@
 class AppointmentPresenter
   include ActiveSupport::Inflector
 
-  def initialize(appointment = {})
+  def initialize(appointment = {}, verifier: ActiveSupport::MessageVerifier)
     @appointment = appointment
+    @verifier = verifier
   end
 
   def appointment_id
-    [
-      @appointment.fetch('beginDate'),
-      @appointment.fetch('endDate'),
-    ].join('|')
+    @verifier
+      .new(encryption_secret)
+      .generate(@appointment)
   end
 
   def description
@@ -67,5 +67,9 @@ class AppointmentPresenter
              end
 
     I18n.l(time, format: format).strip
+  end
+
+  def encryption_secret
+    ENV.fetch('ENCRYPTION_SECRET')
   end
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -2,176 +2,178 @@ require 'rails_helper'
 
 RSpec.feature 'Resident can see a confirmation of their repair request' do
   scenario 'when the issue was diagnosed and an appointment was booked' do
-    property = {
-      'propertyReference' => '00000503',
-      'address' => 'Ross Court 23',
-      'postcode' => 'E5 8TE',
-    }
-    fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
-    allow(fake_api).to receive(:post)
-      .with('v1/repairs', anything)
-      .and_return(
-        'repairRequestReference' => '00367923',
-        'priority' => 'N',
-        'problem' => "My sink is blocked\n\nRoom: Kitchen",
+    ClimateControl.modify(ENCRYPTION_SECRET: 'test') do
+      property = {
         'propertyReference' => '00000503',
-        'workOrders' => [
-          {
-            'sorCode' => '0078965',
-            'workOrderReference' => '09124578',
-          },
+        'address' => 'Ross Court 23',
+        'postcode' => 'E5 8TE',
+      }
+      fake_api = instance_double(JsonApi)
+      allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
+      allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
+      allow(fake_api).to receive(:post)
+        .with('v1/repairs', anything)
+        .and_return(
+          'repairRequestReference' => '00367923',
+          'priority' => 'N',
+          'problem' => "My sink is blocked\n\nRoom: Kitchen",
+          'propertyReference' => '00000503',
+          'workOrders' => [
+            {
+              'sorCode' => '0078965',
+              'workOrderReference' => '09124578',
+            },
+          ]
+        )
+      allow(fake_api).to receive(:get)
+        .with('v1/repairs/00367923')
+        .and_return(
+          'repairRequestReference' => '00367923',
+          'priority' => 'N',
+          'problem' => "My sink is blocked\n\nRoom: Kitchen",
+          'propertyReference' => '00000503',
+          'workOrders' => [
+            {
+              'sorCode' => '0078965',
+              'workOrderReference' => '09124578',
+            },
+          ]
+        )
+      allow(fake_api).to receive(:get)
+        .with('v1/work_orders/09124578/available_appointments')
+        .and_return(
+          'results' => [
+            { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
+            { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
+          ]
+        )
+      allow(fake_api).to receive(:post)
+        .with(
+          'v1/work_orders/09124578/appointments',
+          beginDate: '2017-10-11T12:00:00Z',
+          endDate: '2017-10-11T17:00:00Z',
+        )
+        .and_return(
+          'beginDate' => '2017-10-11T12:00:00Z',
+          'endDate' => '2017-10-11T17:00:00Z',
+          'status' => 'booked',
+        )
+      allow(JsonApi).to receive(:new).and_return(fake_api)
+
+      fake_question_set = instance_double(QuestionSet)
+      allow(fake_question_set)
+        .to receive(:find)
+        .with('location')
+        .and_return(
+          Question.new(
+            'id' => 'location',
+            'question' => 'Where is the problem located?',
+            'answers' => [
+              { 'text' => 'Inside', 'next' => 'which_room' },
+              { 'text' => 'Outside' },
+            ],
+          )
+        )
+      allow(fake_question_set)
+        .to receive(:find)
+        .with('which_room')
+        .and_return(
+          Question.new(
+            'id' => 'which_room',
+            'question' => 'Which room?',
+            'answers' => [
+              { 'text' => 'Kitchen', 'next' => 'kitchen' },
+              { 'text' => 'Bathroom' },
+              { 'text' => 'Other' },
+            ],
+          )
+        )
+      allow(fake_question_set)
+        .to receive(:find)
+        .with('kitchen')
+        .and_return(
+          Question.new(
+            'id' => 'kitchen',
+            'question' => 'Is your tap broken?',
+            'answers' => [
+              { 'text' => 'Yes', 'sor_code' => '0078965' },
+              { 'text' => 'No' },
+            ],
+          )
+        )
+      allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+
+      visit '/'
+      click_on 'Start'
+
+      # Emergency page:
+      choose_radio_button 'No'
+      click_on 'Continue'
+
+      # Fake decision tree
+      choose_radio_button 'Inside'
+      click_on 'Continue'
+      choose_radio_button 'Kitchen'
+      click_on 'Continue'
+
+      choose_radio_button 'Yes'
+      click_on 'Continue'
+
+      # Describe problem:
+      fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+      click_on 'Continue'
+
+      # Address search:
+      fill_in 'Postcode', with: 'E5 8TE'
+      click_on 'Find my address'
+
+      # Address selection:
+      choose_radio_button 'Ross Court 23'
+      click_on 'Continue'
+
+      # Contact details:
+      fill_in 'Full name', with: 'John Evans'
+      fill_in 'Telephone number', with: '078 98765 432'
+      click_on 'Continue'
+
+      # Appointments:
+      choose_radio_button 'Wednesday midday to 5pm (11th October)'
+      click_on 'Continue'
+
+      aggregate_failures do
+        within '#confirmation' do
+          expect(page).to have_content 'Your reference number is 09124578'
+          expect(page).to have_content 'Wednesday 11th October'
+          expect(page).to have_content 'between midday and 5pm'
+        end
+
+        within '#summary' do
+          expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
+          expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
+          expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
+        end
+      end
+
+      expect(fake_api).to have_received(:post).with(
+        'v1/repairs',
+        priority: 'N',
+        problemDescription: "My sink is blocked\n\nRoom: Kitchen",
+        propertyReference: '00000503',
+        contact: {
+          name: 'John Evans',
+          telephoneNumber: '078 98765 432',
+        },
+        workOrders: [
+          { sorCode: '0078965' },
         ]
       )
-    allow(fake_api).to receive(:get)
-      .with('v1/repairs/00367923')
-      .and_return(
-        'repairRequestReference' => '00367923',
-        'priority' => 'N',
-        'problem' => "My sink is blocked\n\nRoom: Kitchen",
-        'propertyReference' => '00000503',
-        'workOrders' => [
-          {
-            'sorCode' => '0078965',
-            'workOrderReference' => '09124578',
-          },
-        ]
-      )
-    allow(fake_api).to receive(:get)
-      .with('v1/work_orders/09124578/available_appointments')
-      .and_return(
-        'results' => [
-          { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
-          { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
-        ]
-      )
-    allow(fake_api).to receive(:post)
-      .with(
+
+      expect(fake_api).to have_received(:post).with(
         'v1/work_orders/09124578/appointments',
         beginDate: '2017-10-11T12:00:00Z',
         endDate: '2017-10-11T17:00:00Z',
       )
-      .and_return(
-        'beginDate' => '2017-10-11T12:00:00Z',
-        'endDate' => '2017-10-11T17:00:00Z',
-        'status' => 'booked',
-      )
-    allow(JsonApi).to receive(:new).and_return(fake_api)
-
-    fake_question_set = instance_double(QuestionSet)
-    allow(fake_question_set)
-      .to receive(:find)
-      .with('location')
-      .and_return(
-        Question.new(
-          'id' => 'location',
-          'question' => 'Where is the problem located?',
-          'answers' => [
-            { 'text' => 'Inside', 'next' => 'which_room' },
-            { 'text' => 'Outside' },
-          ],
-        )
-      )
-    allow(fake_question_set)
-      .to receive(:find)
-      .with('which_room')
-      .and_return(
-        Question.new(
-          'id' => 'which_room',
-          'question' => 'Which room?',
-          'answers' => [
-            { 'text' => 'Kitchen', 'next' => 'kitchen' },
-            { 'text' => 'Bathroom' },
-            { 'text' => 'Other' },
-          ],
-        )
-      )
-    allow(fake_question_set)
-      .to receive(:find)
-      .with('kitchen')
-      .and_return(
-        Question.new(
-          'id' => 'kitchen',
-          'question' => 'Is your tap broken?',
-          'answers' => [
-            { 'text' => 'Yes', 'sor_code' => '0078965' },
-            { 'text' => 'No' },
-          ],
-        )
-      )
-    allow(QuestionSet).to receive(:new).and_return(fake_question_set)
-
-    visit '/'
-    click_on 'Start'
-
-    # Emergency page:
-    choose_radio_button 'No'
-    click_on 'Continue'
-
-    # Fake decision tree
-    choose_radio_button 'Inside'
-    click_on 'Continue'
-    choose_radio_button 'Kitchen'
-    click_on 'Continue'
-
-    choose_radio_button 'Yes'
-    click_on 'Continue'
-
-    # Describe problem:
-    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
-    click_on 'Continue'
-
-    # Address search:
-    fill_in 'Postcode', with: 'E5 8TE'
-    click_on 'Find my address'
-
-    # Address selection:
-    choose_radio_button 'Ross Court 23'
-    click_on 'Continue'
-
-    # Contact details:
-    fill_in 'Full name', with: 'John Evans'
-    fill_in 'Telephone number', with: '078 98765 432'
-    click_on 'Continue'
-
-    # Appointments:
-    choose_radio_button 'Wednesday midday to 5pm (11th October)'
-    click_on 'Continue'
-
-    aggregate_failures do
-      within '#confirmation' do
-        expect(page).to have_content 'Your reference number is 09124578'
-        expect(page).to have_content 'Wednesday 11th October'
-        expect(page).to have_content 'between midday and 5pm'
-      end
-
-      within '#summary' do
-        expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
-        expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
-        expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
-      end
     end
-
-    expect(fake_api).to have_received(:post).with(
-      'v1/repairs',
-      priority: 'N',
-      problemDescription: "My sink is blocked\n\nRoom: Kitchen",
-      propertyReference: '00000503',
-      contact: {
-        name: 'John Evans',
-        telephoneNumber: '078 98765 432',
-      },
-      workOrders: [
-        { sorCode: '0078965' },
-      ]
-    )
-
-    expect(fake_api).to have_received(:post).with(
-      'v1/work_orders/09124578/appointments',
-      beginDate: '2017-10-11T12:00:00Z',
-      endDate: '2017-10-11T17:00:00Z',
-    )
   end
 
   scenario 'when the issue could not be completely diagnosed (and a callback is required)' do

--- a/spec/models/appointment_form_spec.rb
+++ b/spec/models/appointment_form_spec.rb
@@ -8,35 +8,85 @@ RSpec.describe AppointmentForm do
 
       expect(form.errors.details[:appointment_id]).to include(error: :blank)
     end
-
-    it 'raises an exception if appointment_id does not contain two dates' do
-      input = { appointment_id: '2017-12-25:12:34:56Z' }
-
-      expect { AppointmentForm.new(input) }
-        .to raise_error(AppointmentForm::InvalidAppointment)
-    end
-
-    it 'raises an exception if appointment_id is not formatted correctly' do
-      input = { appointment_id: 'invalid|2017-12-25:10:10:10Z' }
-
-      expect { AppointmentForm.new(input) }
-        .to raise_error(AppointmentForm::InvalidAppointment)
-    end
   end
 
   describe '#begin_date'  do
     it 'is extracted from the appointment_id parameter' do
-      input = { appointment_id: '2017-11-09T10:00:00Z|2017-11-09T12:00:00Z' }
+      ClimateControl.modify(ENCRYPTION_SECRET: 'test') do
+        appointment = { 'beginDate' => '2017-11-09T10:00:00Z' }
+        input = { appointment_id: appointment }
 
-      expect(AppointmentForm.new(input).begin_date).to eql '2017-11-09T10:00:00Z'
+        fake_message_verifier_instance = instance_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier_instance).to receive(:verify)
+          .and_return(appointment)
+
+        fake_message_verifier = class_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier).to receive(:new)
+          .with('test')
+          .and_return(fake_message_verifier_instance)
+
+        expect(AppointmentForm.new(input, verifier: fake_message_verifier).begin_date)
+          .to eql '2017-11-09T10:00:00Z'
+      end
+    end
+
+    it 'raises an error if it has been tampered with' do
+      ClimateControl.modify(ENCRYPTION_SECRET: 'test') do
+        appointment = { 'beginDate' => '2017-11-09T10:00:00Z' }
+        input = { appointment_id: appointment }
+
+        fake_message_verifier_instance = instance_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier_instance).to receive(:verify)
+          .and_raise('ActiveSupport::MessageVerifier::InvalidSignature')
+
+        fake_message_verifier = class_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier).to receive(:new)
+          .with('test')
+          .and_return(fake_message_verifier_instance)
+
+        expect { AppointmentForm.new(input, verifier: fake_message_verifier).end_date }
+          .to raise_error('ActiveSupport::MessageVerifier::InvalidSignature')
+      end
     end
   end
 
   describe '#end_date' do
     it 'is extracted from the appointment_id parameter' do
-      input = { appointment_id: '2017-11-09T10:00:00Z|2017-11-09T12:00:00Z' }
+      ClimateControl.modify(ENCRYPTION_SECRET: 'test') do
+        appointment = { 'endDate' => '2017-11-09T12:00:00Z' }
+        input = { appointment_id: appointment }
 
-      expect(AppointmentForm.new(input).end_date).to eql '2017-11-09T12:00:00Z'
+        fake_message_verifier_instance = instance_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier_instance).to receive(:verify)
+          .and_return(appointment)
+
+        fake_message_verifier = class_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier).to receive(:new)
+          .with('test')
+          .and_return(fake_message_verifier_instance)
+
+        expect(AppointmentForm.new(input, verifier: fake_message_verifier).end_date)
+          .to eql '2017-11-09T12:00:00Z'
+      end
+    end
+
+    it 'raises an error if it has been tampered with' do
+      ClimateControl.modify(ENCRYPTION_SECRET: 'test') do
+        appointment = { 'endDate' => '2017-11-09T12:00:00Z' }
+        input = { appointment_id: appointment }
+
+        fake_message_verifier_instance = instance_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier_instance).to receive(:verify)
+          .and_raise('ActiveSupport::MessageVerifier::InvalidSignature')
+
+        fake_message_verifier = class_double('ActiveSupport::MessageVerifier')
+        expect(fake_message_verifier).to receive(:new)
+          .with('test')
+          .and_return(fake_message_verifier_instance)
+
+        expect { AppointmentForm.new(input, verifier: fake_message_verifier).end_date }
+          .to raise_error('ActiveSupport::MessageVerifier::InvalidSignature')
+      end
     end
   end
 end


### PR DESCRIPTION
Because appointments returned from the API don't have a simple id to reference them, I used the `beginDate` and `endDate` concatenated together instead.

This comes with a major drawback - we're trusting the contents of these fields between coming out of the API, being used in the user's browser and being used to book an appointment. So there's a chance that the user could manipulate the time range to their advantage.

Using `ActiveSupport::MessageVerifier` I encrypt the appointment hash and use that as the 'value' for the radio button in the appointment form. This data is then decrypted and then sent to the API in order to book the appointment.

Now, if someone attempts to alter the radio button value, an exception is thrown.