### PR TITLE
(255) Check that all referenced pages exist

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,14 +1,12 @@
 class QuestionsController < ApplicationController
   def show
     @form = QuestionForm.new
-    @question = QuestionSet.new(partial_checker: description_partial_checker)
-                           .find(params[:id])
+    @question = questions.find(params[:id])
   end
 
   def submit
     @form = QuestionForm.new(question_form_params)
-    @question = QuestionSet.new(partial_checker: description_partial_checker)
-                           .find(params[:id])
+    @question = questions.find(params[:id])
 
     question_saver =
       QuestionSaver.new(
@@ -27,5 +25,12 @@ class QuestionsController < ApplicationController
 
   def question_form_params
     params.require(:question_form).permit(:answer)
+  end
+
+  def questions
+    QuestionSet.new(
+      partial_checker: description_partial_checker,
+      page_checker: StaticPageChecker.new(lookup_context: lookup_context)
+    )
   end
 end

--- a/app/models/question_set.rb
+++ b/app/models/question_set.rb
@@ -3,9 +3,10 @@ class QuestionSet
   class UnknownQuestion < Error; end
   class BadlyFormattedYaml < Error; end
 
-  def initialize(filename = 'db/questions.yml', partial_checker:)
+  def initialize(filename = 'db/questions.yml', partial_checker:, page_checker:)
     validator = QuestionsValidator.new(
       partial_checker: partial_checker,
+      page_checker: page_checker,
       mandatory_questions: %w[location which_room]
     )
     loader = QuestionSetLoader.new(validator: validator)

--- a/app/models/question_set.rb
+++ b/app/models/question_set.rb
@@ -4,7 +4,11 @@ class QuestionSet
   class BadlyFormattedYaml < Error; end
 
   def initialize(filename = 'db/questions.yml', partial_checker:)
-    loader = QuestionSetLoader.new(partial_checker: partial_checker)
+    validator = QuestionsValidator.new(
+      partial_checker: partial_checker,
+      mandatory_questions: %w[location which_room]
+    )
+    loader = QuestionSetLoader.new(validator: validator)
     file_path = Rails.root.join(filename)
     @questions = loader.load!(file_path)
   end
@@ -19,22 +23,15 @@ class QuestionSet
   end
 
   class QuestionSetLoader
-    def initialize(partial_checker:)
-      @partial_checker = partial_checker
+    def initialize(validator:)
+      @validator = validator
     end
 
     def load!(file_path)
       yaml_data = File.read(file_path)
-      questions = parse_yaml(yaml_data).to_ruby
-
-      QuestionsValidator
-        .new(
-          questions,
-          partial_checker: @partial_checker,
-          mandatory_questions: %w[location which_room]
-        ).validate!
-
-      questions
+      parse_yaml(yaml_data).to_ruby.tap do |questions|
+        @validator.validate!(questions)
+      end
     end
 
     private

--- a/app/models/questions_validator.rb
+++ b/app/models/questions_validator.rb
@@ -3,9 +3,13 @@ class QuestionsValidator
   class MissingQuestions < Error; end
   class MissingMandatoryQuestions < Error; end
   class MissingPartials < Error; end
+  class MissingPages < Error; end
 
-  def initialize(partial_checker:, mandatory_questions: [])
+  def initialize(partial_checker:,
+                 page_checker:,
+                 mandatory_questions: [])
     @partial_checker = partial_checker
+    @page_checker = page_checker
     @mandatory_questions = mandatory_questions
   end
 
@@ -14,6 +18,7 @@ class QuestionsValidator
     validate_next!(questions)
     validate_desc!(questions)
     validate_mandatory!(questions)
+    validate_page!(questions)
   end
 
   private
@@ -37,6 +42,14 @@ class QuestionsValidator
 
     return if missing_question_ids.empty?
     raise MissingMandatoryQuestions, missing_question_ids
+  end
+
+  def validate_page!(questions)
+    missing_pages = questions.answer_values_for('page').reject do |page_name|
+      @page_checker.exists?(page_name)
+    end
+
+    raise MissingPages, missing_pages if missing_pages.any?
   end
 
   class Questions

--- a/app/models/questions_validator.rb
+++ b/app/models/questions_validator.rb
@@ -4,49 +4,55 @@ class QuestionsValidator
   class MissingMandatoryQuestions < Error; end
   class MissingPartials < Error; end
 
-  def initialize(questions, partial_checker:, mandatory_questions: [])
-    @questions = questions
+  def initialize(partial_checker:, mandatory_questions: [])
     @partial_checker = partial_checker
     @mandatory_questions = mandatory_questions
   end
 
-  def validate!
-    validate_next
-    validate_desc
-    validate_mandatory
+  def validate!(questions)
+    questions = Questions.new(questions)
+    validate_next!(questions)
+    validate_desc!(questions)
+    validate_mandatory!(questions)
   end
 
   private
 
-  def validate_next
-    missing_question_ids = answer_values_for('next') - question_ids
+  def validate_next!(questions)
+    missing_question_ids = questions.answer_values_for('next') - questions.ids
 
     raise MissingQuestions, missing_question_ids if missing_question_ids.any?
   end
 
-  def validate_desc
-    missing_partials = answer_values_for('desc').reject do |partial_name|
-      @partial_checker.exists?(partial_name)
+  def validate_desc!(questions)
+    missing_partials = questions.answer_values_for('desc').reject do |partial|
+      @partial_checker.exists?(partial)
     end
 
     raise MissingPartials, missing_partials if missing_partials.any?
   end
 
-  def validate_mandatory
-    missing_question_ids = @mandatory_questions - question_ids
+  def validate_mandatory!(questions)
+    missing_question_ids = @mandatory_questions - questions.ids
 
     return if missing_question_ids.empty?
     raise MissingMandatoryQuestions, missing_question_ids
   end
 
-  def question_ids
-    @questions.keys.uniq
-  end
+  class Questions
+    def initialize(questions)
+      @questions = questions
+    end
 
-  def answer_values_for(answer_type)
-    @questions.reduce([]) do |ids, (_k, v)|
-      answers = Array(v['answers'])
-      ids + answers.map { |a| a[answer_type] }.compact
+    def ids
+      @questions.keys.uniq
+    end
+
+    def answer_values_for(answer_type)
+      @questions.reduce([]) do |ids, (_k, v)|
+        answers = Array(v['answers'])
+        ids + answers.map { |a| a[answer_type] }.compact
+      end
     end
   end
 end

--- a/app/models/static_page_checker.rb
+++ b/app/models/static_page_checker.rb
@@ -1,0 +1,10 @@
+class StaticPageChecker
+  def initialize(lookup_context:)
+    @lookup_context = lookup_context
+  end
+
+  def exists?(page_name)
+    return false if page_name.nil?
+    @lookup_context.exists?(page_name, 'pages')
+  end
+end

--- a/spec/models/question_set_spec.rb
+++ b/spec/models/question_set_spec.rb
@@ -4,27 +4,27 @@ RSpec.describe QuestionSet do
   describe '#initialize' do
     it 'throws an error if the YAML file is not in the correct format' do
       expect do
-        QuestionSet.new('spec/fixtures/broken.yml', partial_checker: double)
+        QuestionSet.new('spec/fixtures/broken.yml', partial_checker: double, page_checker: double)
       end.to raise_error(QuestionSet::BadlyFormattedYaml)
     end
 
     it 'throws an error if the YAML file links to a missing question' do
       expect do
-        QuestionSet.new('spec/fixtures/missing_questions.yml', partial_checker: double)
+        QuestionSet.new('spec/fixtures/missing_questions.yml', partial_checker: double, page_checker: double)
       end.to raise_error(QuestionsValidator::MissingQuestions)
     end
 
     it 'throws an error if the YAML file links to a missing description partial' do
       partial_checker = instance_double('DescriptionPartialChecker', exists?: false)
       expect do
-        QuestionSet.new('spec/fixtures/missing_partials.yml', partial_checker: partial_checker)
+        QuestionSet.new('spec/fixtures/missing_partials.yml', partial_checker: partial_checker, page_checker: double)
       end.to raise_error(QuestionsValidator::MissingPartials)
     end
   end
 
   describe '#find' do
     it 'returns the requested question' do
-      store = QuestionSet.new('spec/fixtures/basic_question.yml', partial_checker: double)
+      store = QuestionSet.new('spec/fixtures/basic_question.yml', partial_checker: double, page_checker: double)
       question = store.find('example')
 
       expect(question).to be_a(Question)
@@ -32,7 +32,7 @@ RSpec.describe QuestionSet do
     end
 
     it 'raises an error if the requested question was not found' do
-      store = QuestionSet.new('spec/fixtures/basic_question.yml', partial_checker: double)
+      store = QuestionSet.new('spec/fixtures/basic_question.yml', partial_checker: double, page_checker: double)
 
       expect { store.find('wrong') }.to raise_error QuestionSet::UnknownQuestion
     end

--- a/spec/models/questions_validator_spec.rb
+++ b/spec/models/questions_validator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe QuestionsValidator do
         },
       }
       partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(questions, partial_checker: partial_checker).validate! }
+      expect { QuestionsValidator.new(partial_checker: partial_checker).validate!(questions) }
         .to raise_error(QuestionsValidator::MissingQuestions)
     end
 
@@ -33,7 +33,7 @@ RSpec.describe QuestionsValidator do
         },
       }
       partial_checker = instance_double('DescriptionPartialChecker', exists?: false)
-      expect { QuestionsValidator.new(questions, partial_checker: partial_checker).validate! }
+      expect { QuestionsValidator.new(partial_checker: partial_checker).validate!(questions) }
         .to raise_error(QuestionsValidator::MissingPartials)
     end
 
@@ -50,7 +50,7 @@ RSpec.describe QuestionsValidator do
         },
       }
       partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(questions, partial_checker: partial_checker).validate! }
+      expect { QuestionsValidator.new(partial_checker: partial_checker).validate!(questions) }
         .to_not raise_error
     end
   end
@@ -68,14 +68,14 @@ RSpec.describe QuestionsValidator do
         },
       }
       partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(questions, partial_checker: partial_checker, mandatory_questions: ['location']).validate! }
+      expect { QuestionsValidator.new(partial_checker: partial_checker, mandatory_questions: ['location']).validate!(questions) }
         .to_not raise_error
     end
 
     it 'throws an error if these questions are not included' do
       questions = {}
       partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(questions, partial_checker: partial_checker, mandatory_questions: ['which_room']).validate! }
+      expect { QuestionsValidator.new(partial_checker: partial_checker, mandatory_questions: ['which_room']).validate!(questions) }
         .to raise_error(QuestionsValidator::MissingMandatoryQuestions)
     end
   end

--- a/spec/models/questions_validator_spec.rb
+++ b/spec/models/questions_validator_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe QuestionsValidator do
           ],
         },
       }
-      partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(partial_checker: partial_checker).validate!(questions) }
+      expect { QuestionsValidator.new(partial_checker: double, page_checker: double).validate!(questions) }
         .to raise_error(QuestionsValidator::MissingQuestions)
     end
 
@@ -33,7 +32,7 @@ RSpec.describe QuestionsValidator do
         },
       }
       partial_checker = instance_double('DescriptionPartialChecker', exists?: false)
-      expect { QuestionsValidator.new(partial_checker: partial_checker).validate!(questions) }
+      expect { QuestionsValidator.new(partial_checker: partial_checker, page_checker: double).validate!(questions) }
         .to raise_error(QuestionsValidator::MissingPartials)
     end
 
@@ -50,7 +49,41 @@ RSpec.describe QuestionsValidator do
         },
       }
       partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(partial_checker: partial_checker).validate!(questions) }
+      expect { QuestionsValidator.new(partial_checker: partial_checker, page_checker: double).validate!(questions) }
+        .to_not raise_error
+    end
+
+    it 'throws an error if there is a link to a page which does not exist' do
+      questions = {
+        'location' => {
+          'question' => 'What is the problem?',
+          'answers' => [
+            {
+              'text' => 'Something which requires a page',
+              'page' => 'a_page_which_does_not_exist',
+            },
+          ],
+        },
+      }
+      page_checker = instance_double('PageChecker', exists?: false)
+      expect { QuestionsValidator.new(partial_checker: double, page_checker: page_checker).validate!(questions) }
+        .to raise_error(QuestionsValidator::MissingPages)
+    end
+
+    it 'passes if there is a link to a page which exists' do
+      questions = {
+        'location' => {
+          'question' => 'What is the problem?',
+          'answers' => [
+            {
+              'text' => 'Something which requires a page',
+              'page' => 'a_page_which_exists',
+            },
+          ],
+        },
+      }
+      page_checker = instance_double('PageChecker', exists?: true)
+      expect { QuestionsValidator.new(partial_checker: double, page_checker: page_checker).validate!(questions) }
         .to_not raise_error
     end
   end
@@ -67,15 +100,13 @@ RSpec.describe QuestionsValidator do
           ],
         },
       }
-      partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(partial_checker: partial_checker, mandatory_questions: ['location']).validate!(questions) }
+      expect { QuestionsValidator.new(partial_checker: double, page_checker: double, mandatory_questions: ['location']).validate!(questions) }
         .to_not raise_error
     end
 
     it 'throws an error if these questions are not included' do
       questions = {}
-      partial_checker = instance_double('DescriptionPartialChecker', exists?: true)
-      expect { QuestionsValidator.new(partial_checker: partial_checker, mandatory_questions: ['which_room']).validate!(questions) }
+      expect { QuestionsValidator.new(partial_checker: double, page_checker: double, mandatory_questions: ['which_room']).validate!(questions) }
         .to raise_error(QuestionsValidator::MissingMandatoryQuestions)
     end
   end

--- a/spec/models/static_page_checker_spec.rb
+++ b/spec/models/static_page_checker_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'app/models/static_page_checker'
+
+RSpec.describe StaticPageChecker do
+  describe '#exists?' do
+    context 'when the page exists' do
+      it 'is true' do
+        fake_lookup_context = instance_double('ActionView::LookupContext')
+        allow(fake_lookup_context).to receive(:exists?)
+          .with('a_real_page', 'pages')
+          .and_return(true)
+        checker = StaticPageChecker.new(lookup_context: fake_lookup_context)
+        expect(checker.exists?('a_real_page')).to eq true
+      end
+    end
+
+    context 'when the page does not exist' do
+      it 'is true' do
+        fake_lookup_context = instance_double('ActionView::LookupContext')
+        allow(fake_lookup_context).to receive(:exists?)
+          .with('an_imaginary_page', 'pages')
+          .and_return(false)
+        checker = StaticPageChecker.new(lookup_context: fake_lookup_context)
+        expect(checker.exists?('an_imaginary_page')).to eq false
+      end
+    end
+
+    context 'when the page is nil' do
+      it 'is false' do
+        fake_lookup_context = instance_double('ActionView::LookupContext')
+        checker = StaticPageChecker.new(lookup_context: fake_lookup_context)
+        expect(checker.exists?(nil)).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
We found in testing that the 'blocked_only_toilet' page doesn't exist, so
we need a check for pages to make sure we don't have any others.

This is expected to fail since there's one test which actually loads the real questions and there is one missing page. Should be reviewable now and mergeable when that page is created