### PR TITLE
(251) Stop mobile Safari adding links to reference numbers

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,7 @@
 
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1' }/
     %meta{ 'http-equiv': 'x-ua-compatible', content: 'ie-edge' }/
+    %meta{ name: 'format-detection', content: 'telephone=no' }/
 
     = csrf_meta_tags
     %link{ href: 'https://fonts.googleapis.com/css?family=Droid+Sans:400,700', rel: 'stylesheet' }/


### PR DESCRIPTION
Add a meta tag into the `<head>` of all pages to prevent Safari on iOS from auto-detecting phone numbers. We're already adding `tel:...` links to all phone numbers, and this was affecting the output of repair reference numbers.

<img width="324" alt="fixed-ios-reference-number" src="https://user-images.githubusercontent.com/3166/33448627-6925d4a2-d5fe-11e7-8136-3e509f667aa6.png">

Tested in iPhone SE Safari through BrowserStack.