### PR TITLE
(247) Users should call RCC if they cannot make any appointment slot

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -2,6 +2,7 @@ class AppointmentsController < ApplicationController
   def show
     @form = AppointmentForm.new
     @appointments = available_appointments
+    @work_order_reference = work_order_reference
   end
 
   def submit
@@ -9,6 +10,7 @@ class AppointmentsController < ApplicationController
 
     if @form.invalid?
       @appointments = available_appointments
+      @work_order_reference = work_order_reference
       return render :show
     end
 

--- a/app/views/appointments/show.html.haml
+++ b/app/views/appointments/show.html.haml
@@ -12,4 +12,12 @@
         as: :radio_buttons,
         label: false
 
+      %p
+        If you can't make any of these appointments, please call
+        the Repairs Contact Centre on
+        = repairs_contact_centre_telephone_number
+        and quote reference number
+        = succeed '.' do
+          = @work_order_reference
+
       = f.button :submit, class: 'button'


### PR DESCRIPTION
If the user is unable to make any of the available appointment slots, prompt them to call the Repairs Contact Centre, quoting the reference *(aka work order reference number)*.

![cannot-make-appointment](https://user-images.githubusercontent.com/3166/33481765-d014f6fe-d68d-11e7-8c99-84f606f97831.png)