### PR TITLE
(241) Dont show invalid appointments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The app should run successfully without these environment variables:
   `Rack::Timeout` times-out an HTTP request. This is used to ensure that the
   app times out before Heroku automatically kills the connection and displays
   its own, less friendly, error message.
+- `APPOINTMENT_LIMIT` - Set this to override the maximum number of appointments
+  returned from the `AppointmentFetcher` service. Defaults to 15.
 
 #### Feature flagging
 

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -34,11 +34,10 @@ class AppointmentsController < ApplicationController
   end
 
   def available_appointments
-    appointments = HackneyApi.new.list_available_appointments(
-      work_order_reference: work_order_reference
-    )
-
-    appointments.map { |a| AppointmentPresenter.new(a) }
+    AppointmentFetcher
+      .new
+      .call(work_order_reference: work_order_reference)
+      .map { |appointment| AppointmentPresenter.new(appointment) }
   end
 
   def book_appointment_save_into_answer_store

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -36,7 +36,10 @@ class AppointmentsController < ApplicationController
   def available_appointments
     AppointmentFetcher
       .new
-      .call(work_order_reference: work_order_reference)
+      .call(
+        work_order_reference: work_order_reference,
+        limit: ENV.fetch('APPOINTMENT_LIMIT', 15).to_i
+      )
       .map { |appointment| AppointmentPresenter.new(appointment) }
   end
 

--- a/app/services/appointment_fetcher.rb
+++ b/app/services/appointment_fetcher.rb
@@ -3,6 +3,7 @@ class AppointmentFetcher
     @work_order_reference = work_order_reference
 
     appointments = filter_before_tomorrow(available_appointments)
+    appointments = keep_best_slots_only(appointments)
     filter_long_slots(appointments)
   end
 
@@ -29,6 +30,12 @@ class AppointmentFetcher
       appointment_length_in_hours = (end_time - begin_time) / 1.hour
 
       appointment_length_in_hours >= 6
+    end
+  end
+
+  def keep_best_slots_only(appointments)
+    appointments.select do |appointment|
+      appointment.fetch('bestSlot') == true
     end
   end
 end

--- a/app/services/appointment_fetcher.rb
+++ b/app/services/appointment_fetcher.rb
@@ -1,0 +1,15 @@
+class AppointmentFetcher
+  def call(work_order_reference:)
+    @work_order_reference = work_order_reference
+
+    available_appointments
+  end
+
+  private
+
+  def available_appointments
+    HackneyApi.new.list_available_appointments(
+      work_order_reference: @work_order_reference
+    )
+  end
+end

--- a/app/services/appointment_fetcher.rb
+++ b/app/services/appointment_fetcher.rb
@@ -2,7 +2,8 @@ class AppointmentFetcher
   def call(work_order_reference:)
     @work_order_reference = work_order_reference
 
-    available_appointments
+    appointments = filter_before_tomorrow(available_appointments)
+    filter_long_slots(appointments)
   end
 
   private
@@ -11,5 +12,23 @@ class AppointmentFetcher
     HackneyApi.new.list_available_appointments(
       work_order_reference: @work_order_reference
     )
+  end
+
+  def filter_before_tomorrow(appointments)
+    tomorrow = 1.day.from_now.at_beginning_of_day
+
+    appointments.select do |appointment|
+      Time.zone.parse(appointment.fetch('beginDate')) >= tomorrow
+    end
+  end
+
+  def filter_long_slots(appointments)
+    appointments.reject do |appointment|
+      begin_time = Time.zone.parse(appointment.fetch('beginDate'))
+      end_time = Time.zone.parse(appointment.fetch('endDate'))
+      appointment_length_in_hours = (end_time - begin_time) / 1.hour
+
+      appointment_length_in_hours >= 6
+    end
   end
 end

--- a/app/services/appointment_fetcher.rb
+++ b/app/services/appointment_fetcher.rb
@@ -1,10 +1,11 @@
 class AppointmentFetcher
-  def call(work_order_reference:)
+  def call(work_order_reference:, limit:)
     @work_order_reference = work_order_reference
 
     appointments = filter_before_tomorrow(available_appointments)
     appointments = keep_best_slots_only(appointments)
-    filter_long_slots(appointments)
+    appointments = filter_long_slots(appointments)
+    appointments.take(limit)
   end
 
   private

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -49,8 +49,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         .with('v1/work_orders/09124578/available_appointments')
         .and_return(
           'results' => [
-            { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
-            { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
+            { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true },
+            { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => true },
           ]
         )
       allow(fake_api).to receive(:post)

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature 'Resident can see a confirmation of their repair request' do
+  around(:each) do |example|
+    travel_to Time.zone.local(2017, 10, 1) do
+      example.run
+    end
+  end
+
   scenario 'when the issue was diagnosed and an appointment was booked' do
     ClimateControl.modify(ENCRYPTION_SECRET: 'test') do
       property = {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,4 +74,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include CapybaraHelpers, type: :feature
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/services/appointment_fetcher_spec.rb
+++ b/spec/services/appointment_fetcher_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe AppointmentFetcher do
   it 'returns available appointments' do
     available_appointments = [
-      { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
-      { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
+      { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true },
+      { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => true },
     ]
 
     stub_appointments(available_appointments)
@@ -17,9 +17,9 @@ RSpec.describe AppointmentFetcher do
   end
 
   it 'excludes appointment slots before tomorrow' do
-    past_appointment = { 'beginDate' => '2017-10-09T16:00:00Z', 'endDate' => '2017-10-09T18:00:00Z', 'bestSlot' => false }
-    today_appointment = { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false }
-    tomorrow_appointment = { 'beginDate' => '2017-10-12T12:00:00Z', 'endDate' => '2017-10-12T17:00:00Z', 'bestSlot' => false }
+    past_appointment = { 'beginDate' => '2017-10-09T16:00:00Z', 'endDate' => '2017-10-09T18:00:00Z', 'bestSlot' => true }
+    today_appointment = { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true }
+    tomorrow_appointment = { 'beginDate' => '2017-10-12T12:00:00Z', 'endDate' => '2017-10-12T17:00:00Z', 'bestSlot' => true }
 
     stub_appointments([past_appointment, today_appointment, tomorrow_appointment])
 
@@ -33,8 +33,8 @@ RSpec.describe AppointmentFetcher do
   end
 
   it 'excludes all day appointments' do
-    regular_appointment = { 'beginDate' => '2017-10-12T10:00:00Z', 'endDate' => '2017-10-12T14:00:00Z', 'bestSlot' => false }
-    long_appointment = { 'beginDate' => '2017-10-12T09:00:00Z', 'endDate' => '2017-10-12T18:00:00Z', 'bestSlot' => false }
+    regular_appointment = { 'beginDate' => '2017-10-12T10:00:00Z', 'endDate' => '2017-10-12T14:00:00Z', 'bestSlot' => true }
+    long_appointment = { 'beginDate' => '2017-10-12T09:00:00Z', 'endDate' => '2017-10-12T18:00:00Z', 'bestSlot' => true }
 
     stub_appointments([regular_appointment, long_appointment])
 
@@ -43,6 +43,20 @@ RSpec.describe AppointmentFetcher do
 
       expect(appointments).to include regular_appointment
       expect(appointments).not_to include long_appointment
+    end
+  end
+
+  it 'excludes appointments that are not "best" slots' do
+    best_slot = { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true }
+    non_best_slot = { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T14:00:00Z', 'bestSlot' => false }
+
+    stub_appointments([best_slot, non_best_slot])
+
+    travel_to Time.zone.local(2017, 10, 1) do
+      appointments = AppointmentFetcher.new.call(work_order_reference: '1234')
+
+      expect(appointments).to include best_slot
+      expect(appointments).not_to include non_best_slot
     end
   end
 

--- a/spec/services/appointment_fetcher_spec.rb
+++ b/spec/services/appointment_fetcher_spec.rb
@@ -7,13 +7,53 @@ RSpec.describe AppointmentFetcher do
       { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
     ]
 
+    stub_appointments(available_appointments)
+
+    travel_to Time.zone.local(2017, 10, 1) do
+      appointments = AppointmentFetcher.new.call(work_order_reference: '04819510')
+
+      expect(appointments).to eql available_appointments
+    end
+  end
+
+  it 'excludes appointment slots before tomorrow' do
+    past_appointment = { 'beginDate' => '2017-10-09T16:00:00Z', 'endDate' => '2017-10-09T18:00:00Z', 'bestSlot' => false }
+    today_appointment = { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false }
+    tomorrow_appointment = { 'beginDate' => '2017-10-12T12:00:00Z', 'endDate' => '2017-10-12T17:00:00Z', 'bestSlot' => false }
+
+    stub_appointments([past_appointment, today_appointment, tomorrow_appointment])
+
+    travel_to Time.zone.local(2017, 10, 11) do
+      appointments = AppointmentFetcher.new.call(work_order_reference: '1234')
+
+      expect(appointments).to include tomorrow_appointment
+      expect(appointments).not_to include past_appointment
+      expect(appointments).not_to include today_appointment
+    end
+  end
+
+  it 'excludes all day appointments' do
+    regular_appointment = { 'beginDate' => '2017-10-12T10:00:00Z', 'endDate' => '2017-10-12T14:00:00Z', 'bestSlot' => false }
+    long_appointment = { 'beginDate' => '2017-10-12T09:00:00Z', 'endDate' => '2017-10-12T18:00:00Z', 'bestSlot' => false }
+
+    stub_appointments([regular_appointment, long_appointment])
+
+    travel_to Time.zone.local(2017, 10, 1) do
+      appointments = AppointmentFetcher.new.call(work_order_reference: '1234')
+
+      expect(appointments).to include regular_appointment
+      expect(appointments).not_to include long_appointment
+    end
+  end
+
+  private
+
+  def stub_appointments(appointments)
     fake_api = instance_double(HackneyApi)
+
     allow(fake_api).to receive(:list_available_appointments)
-      .and_return(available_appointments)
+      .and_return(appointments)
+
     allow(HackneyApi).to receive(:new).and_return(fake_api)
-
-    appointments = AppointmentFetcher.new.call(work_order_reference: '04819510')
-
-    expect(appointments).to eql available_appointments
   end
 end

--- a/spec/services/appointment_fetcher_spec.rb
+++ b/spec/services/appointment_fetcher_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe AppointmentFetcher do
     stub_appointments(available_appointments)
 
     travel_to Time.zone.local(2017, 10, 1) do
-      appointments = AppointmentFetcher.new.call(work_order_reference: '04819510')
+      appointments = AppointmentFetcher.new.call(
+        work_order_reference: '04819510',
+        limit: 15
+      )
 
       expect(appointments).to eql available_appointments
     end
@@ -24,7 +27,10 @@ RSpec.describe AppointmentFetcher do
     stub_appointments([past_appointment, today_appointment, tomorrow_appointment])
 
     travel_to Time.zone.local(2017, 10, 11) do
-      appointments = AppointmentFetcher.new.call(work_order_reference: '1234')
+      appointments = AppointmentFetcher.new.call(
+        work_order_reference: '1234',
+        limit: 15
+      )
 
       expect(appointments).to include tomorrow_appointment
       expect(appointments).not_to include past_appointment
@@ -39,7 +45,10 @@ RSpec.describe AppointmentFetcher do
     stub_appointments([regular_appointment, long_appointment])
 
     travel_to Time.zone.local(2017, 10, 1) do
-      appointments = AppointmentFetcher.new.call(work_order_reference: '1234')
+      appointments = AppointmentFetcher.new.call(
+        work_order_reference: '1234',
+        limit: 15
+      )
 
       expect(appointments).to include regular_appointment
       expect(appointments).not_to include long_appointment
@@ -53,10 +62,32 @@ RSpec.describe AppointmentFetcher do
     stub_appointments([best_slot, non_best_slot])
 
     travel_to Time.zone.local(2017, 10, 1) do
-      appointments = AppointmentFetcher.new.call(work_order_reference: '1234')
+      appointments = AppointmentFetcher.new.call(
+        work_order_reference: '1234',
+        limit: 15
+      )
 
       expect(appointments).to include best_slot
       expect(appointments).not_to include non_best_slot
+    end
+  end
+
+  it 'returns a limited number of results' do
+    first_slot = { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true }
+    second_slot = { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T14:00:00Z', 'bestSlot' => true }
+    third_slot = { 'beginDate' => '2017-10-11T14:00:00Z', 'endDate' => '2017-10-11T16:00:00Z', 'bestSlot' => true }
+
+    stub_appointments([first_slot, second_slot, third_slot])
+
+    travel_to Time.zone.local(2017, 10, 1) do
+      appointments = AppointmentFetcher.new.call(
+        work_order_reference: '1234',
+        limit: 2
+      )
+
+      expect(appointments).to include first_slot
+      expect(appointments).to include second_slot
+      expect(appointments).not_to include third_slot
     end
   end
 

--- a/spec/services/appointment_fetcher_spec.rb
+++ b/spec/services/appointment_fetcher_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentFetcher do
+  it 'returns available appointments' do
+    available_appointments = [
+      { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false },
+      { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => false },
+    ]
+
+    fake_api = instance_double(HackneyApi)
+    allow(fake_api).to receive(:list_available_appointments)
+      .and_return(available_appointments)
+    allow(HackneyApi).to receive(:new).and_return(fake_api)
+
+    appointments = AppointmentFetcher.new.call(work_order_reference: '04819510')
+
+    expect(appointments).to eql available_appointments
+  end
+end


### PR DESCRIPTION
After requesting available appointment slots from the API, filter the results as follows:

 - Only return 'best' slots
 - Don't return any appointments for the current day or in the past
 - Filter all day appointments (those longer than 6 hours)
 - Return a maximum of 15 appointment slots (controllable via the `APPOINTMENT_LIMIT` environment variable)