### PR TITLE
(267) Log requests we make to the API

### DIFF
--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -95,6 +95,7 @@ class JsonApi
       Faraday.new root, ssl: ssl do |conn|
         conn.adapter Faraday.default_adapter
         conn.response :json
+        conn.response :logger, Rails.logger, headers: true, bodies: true
       end
     end
 


### PR DESCRIPTION
Enable Faraday's built-in logger, so that it's easier to debug issues with the API.