### PR TITLE
(278) Use legacy YouTube embed code

### DIFF
--- a/app/views/pages/damp_and_mould.html.haml
+++ b/app/views/pages/damp_and_mould.html.haml
@@ -10,7 +10,11 @@
   Watch this short video for some advice on dealing
   with damp and mould problem areas in your home.
 
-%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/7nq71pGBGI8?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+%object{ height: '315', width: '560' }
+  %param{ name: 'movie', value: 'http://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US' }/
+  %param{ name: 'allowFullScreen', value: 'true' }/
+  %param{ name: 'allowscriptaccess', value: 'always' }/
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   Select continue if you'd still like to report this repair.

--- a/app/views/pages/heating_repairs.html.haml
+++ b/app/views/pages/heating_repairs.html.haml
@@ -6,7 +6,11 @@
 %h2
   Watch this short video to find out how to fix common heating problems.
 
-%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/ktklk7d0ibY?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+%object{ height: '315', width: '560' }
+  %param{ name: 'movie', value: 'http://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US' }/
+  %param{ name: 'allowFullScreen', value: 'true' }/
+  %param{ name: 'allowscriptaccess', value: 'always' }/
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If your heating still isn't working, call our

--- a/app/views/pages/replace_lightbulb.html.haml
+++ b/app/views/pages/replace_lightbulb.html.haml
@@ -6,7 +6,11 @@
 %p
   Watch this short video for advice on how to replace a light bulb or a lamp in your home.
 
-%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/NZN2AZAMPHY?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+%object{ height: '315', width: '560' }
+  %param{ name: 'movie', value: 'http://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US' }/
+  %param{ name: 'allowFullScreen', value: 'true' }/
+  %param{ name: 'allowscriptaccess', value: 'always' }/
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If you've replaced the bulb and the light still isn't working, please select continue to book an appointment.

--- a/app/views/pages/toilet_unblock_info.html.haml
+++ b/app/views/pages/toilet_unblock_info.html.haml
@@ -6,7 +6,11 @@
 %p
   Watch this short video for advice on how to unblock a toilet in your home.
 
-%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/_zzMhYpaD-o?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+%object{ height: '315', width: '560' }
+  %param{ name: 'movie', value: 'http://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US' }/
+  %param{ name: 'allowFullScreen', value: 'true' }/
+  %param{ name: 'allowscriptaccess', value: 'always' }/
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If your toilet is still blocked, please

--- a/app/views/pages/unblock_sink.html.haml
+++ b/app/views/pages/unblock_sink.html.haml
@@ -6,7 +6,11 @@
 %p
   Watch this short video for advice on how to unblock a sink in your home.
 
-%iframe{ width: '560', height: '315', src: 'https://www.youtube.com/embed/WTJQi7iBgiA?rel=0&amp;showinfo=0', frameborder: '0', allowfullscreen: true }
+%object{ height: '315', width: '560' }
+  %param{ name: 'movie', value: 'http://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US' }/
+  %param{ name: 'allowFullScreen', value: 'true' }/
+  %param{ name: 'allowscriptaccess', value: 'always' }/
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If your sink is still blocked, please


### PR DESCRIPTION
The video sharing code you get from youtube.com only supports new
browsers, as they no longer support Flash video embeds.

However, using the old embed code still works in modern browsers, but
additionally provides a fallback for IE8 and older - which shows the
video thumbnail with a button that links to the YouTube video on their
site directly:

![youtube-ie8](https://user-images.githubusercontent.com/3166/33602921-bbdb0a8e-d9a8-11e7-9dc7-973b5e9af31b.jpg)

