### PR TITLE
(fix) Request YouTube videos over SSL

### DIFF
--- a/app/views/pages/damp_and_mould.html.haml
+++ b/app/views/pages/damp_and_mould.html.haml
@@ -11,10 +11,10 @@
   with damp and mould problem areas in your home.
 
 %object{ height: '315', width: '560' }
-  %param{ name: 'movie', value: 'http://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US' }/
+  %param{ name: 'movie', value: 'https://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   Select continue if you'd still like to report this repair.

--- a/app/views/pages/heating_repairs.html.haml
+++ b/app/views/pages/heating_repairs.html.haml
@@ -7,10 +7,10 @@
   Watch this short video to find out how to fix common heating problems.
 
 %object{ height: '315', width: '560' }
-  %param{ name: 'movie', value: 'http://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US' }/
+  %param{ name: 'movie', value: 'https://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If your heating still isn't working, call our

--- a/app/views/pages/replace_lightbulb.html.haml
+++ b/app/views/pages/replace_lightbulb.html.haml
@@ -7,10 +7,10 @@
   Watch this short video for advice on how to replace a light bulb or a lamp in your home.
 
 %object{ height: '315', width: '560' }
-  %param{ name: 'movie', value: 'http://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US' }/
+  %param{ name: 'movie', value: 'https://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If you've replaced the bulb and the light still isn't working, please select continue to book an appointment.

--- a/app/views/pages/toilet_unblock_info.html.haml
+++ b/app/views/pages/toilet_unblock_info.html.haml
@@ -7,10 +7,10 @@
   Watch this short video for advice on how to unblock a toilet in your home.
 
 %object{ height: '315', width: '560' }
-  %param{ name: 'movie', value: 'http://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US' }/
+  %param{ name: 'movie', value: 'https://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If your toilet is still blocked, please

--- a/app/views/pages/unblock_sink.html.haml
+++ b/app/views/pages/unblock_sink.html.haml
@@ -7,10 +7,10 @@
   Watch this short video for advice on how to unblock a sink in your home.
 
 %object{ height: '315', width: '560' }
-  %param{ name: 'movie', value: 'http://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US' }/
+  %param{ name: 'movie', value: 'https://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'http://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
 
 %p
   If your sink is still blocked, please


### PR DESCRIPTION
Whilst this worked in local development, once it was deployed browsers
blocked the YouTube content, as it was being requested over HTTP rather
than HTTPS.