### PR TITLE
(273) Include last question in the description

### DIFF
--- a/app/models/repair_params.rb
+++ b/app/models/repair_params.rb
@@ -6,6 +6,7 @@ class RepairParams
   def problem_description
     lines = [description]
     lines << "Room: #{room}" if room.present?
+    lines << "Last question: #{last_question}"
     lines << "Callback requested: between #{callback_time}" if callback_time
     lines.compact.join("\n\n")
   end
@@ -44,6 +45,11 @@ class RepairParams
 
   def room
     @answers.dig('room', 'room')
+  end
+
+  def last_question
+    question = @answers.fetch('last_question')
+    %("#{question.fetch('question')}" -> #{question.fetch('answer')})
   end
 
   def callback_time

--- a/app/services/question_saver.rb
+++ b/app/services/question_saver.rb
@@ -18,6 +18,7 @@ class QuestionSaver
   def persist_answers(form)
     persist_room(form)
     persist_sor_code(form)
+    persist_last_question(form)
   end
 
   def persist_room(form)
@@ -35,5 +36,23 @@ class QuestionSaver
       :diagnosis,
       sor_code: sor_code
     )
+  end
+
+  def persist_last_question(form)
+    answer = @question.answer_data(form.answer)
+    return unless last_question?(answer)
+    @selected_answer_store.store_selected_answers(
+      :last_question,
+      question: @question.title,
+      answer: answer['text']
+    )
+  end
+
+  def last_question?(answer)
+    answer['desc'] || !explicit_redirect?(answer)
+  end
+
+  def explicit_redirect?(answer)
+    %w[desc next page].any? { |key| answer.key?(key) }
   end
 end

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
-          'problem' => "My sink is blocked\n\nRoom: Kitchen",
+          'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
           'propertyReference' => '00000503',
           'workOrders' => [
             {
@@ -36,7 +36,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
-          'problem' => "My sink is blocked\n\nRoom: Kitchen",
+          'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
           'propertyReference' => '00000503',
           'workOrders' => [
             {
@@ -89,7 +89,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
             'id' => 'kitchen',
             'question' => 'Is your tap broken?',
             'answers' => [
-              { 'text' => 'Yes', 'sor_code' => '0078965' },
+              { 'text' => 'Yes', 'sor_code' => '0078965', 'desc' => 'kitchen_problem' },
               { 'text' => 'No' },
             ],
           )
@@ -148,7 +148,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       expect(fake_api).to have_received(:post).with(
         'v1/repairs',
         priority: 'N',
-        problemDescription: "My sink is blocked\n\nRoom: Kitchen",
+        problemDescription: "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
         propertyReference: '00000503',
         contact: {
           name: 'John Evans',
@@ -181,7 +181,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
-        'problem' => "My sink is blocked\n\nRoom: Other",
+        'problem' => "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other",
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
@@ -189,7 +189,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
-        'problem' => "My sink is blocked\n\nRoom: Other",
+        'problem' => "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other",
         'propertyReference' => '00000503',
       )
     allow(JsonApi).to receive(:new).and_return(fake_api)
@@ -205,7 +205,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           'answers' => [
             { 'text' => 'Kitchen', 'next' => 'kitchen' },
             { 'text' => 'Bathroom' },
-            { 'text' => 'Other' },
+            { 'text' => 'Other', 'desc' => 'describe_problem' },
           ],
         )
       )
@@ -257,7 +257,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     expect(fake_api).to have_received(:post).with(
       'v1/repairs',
       priority: 'N',
-      problemDescription: "My sink is blocked\n\nRoom: Other\n\nCallback requested: between 8am and 5pm",
+      problemDescription: "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other\n\nCallback requested: between 8am and 5pm",
       propertyReference: '00000503',
       contact: {
         name: 'John Evans',

--- a/spec/models/repair_params_spec.rb
+++ b/spec/models/repair_params_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe RepairParams do
         'describe_repair' => {
           'description' => 'My bath is broken',
         },
+        'last_question' => {
+          'question' => 'Is it?',
+          'answer' => 'No',
+        },
       }
-      expect(RepairParams.new(answers).problem_description).to eq 'My bath is broken'
+      expect(RepairParams.new(answers).problem_description).to eq "My bath is broken\n\nLast question: \"Is it?\" -> No"
     end
 
     context 'if no description was provided' do
@@ -20,8 +24,12 @@ RSpec.describe RepairParams do
           'describe_repair' => {
             'description' => '',
           },
+          'last_question' => {
+            'question' => 'Is it?',
+            'answer' => 'No',
+          },
         }
-        expect(RepairParams.new(answers).problem_description).to eq 'No description given'
+        expect(RepairParams.new(answers).problem_description).to eq "No description given\n\nLast question: \"Is it?\" -> No"
       end
     end
 
@@ -34,8 +42,12 @@ RSpec.describe RepairParams do
           'room' => {
             'room' => 'Bathroom',
           },
+          'last_question' => {
+            'question' => 'Is it?',
+            'answer' => 'No',
+          },
         }
-        expect(RepairParams.new(answers).problem_description).to eq "My bath is broken\n\nRoom: Bathroom"
+        expect(RepairParams.new(answers).problem_description).to eq "My bath is broken\n\nRoom: Bathroom\n\nLast question: \"Is it?\" -> No"
       end
 
       it 'describes the room if there was no description' do
@@ -46,8 +58,12 @@ RSpec.describe RepairParams do
           'room' => {
             'room' => 'Bathroom',
           },
+          'last_question' => {
+            'question' => 'Is it?',
+            'answer' => 'No',
+          },
         }
-        expect(RepairParams.new(answers).problem_description).to eq "No description given\n\nRoom: Bathroom"
+        expect(RepairParams.new(answers).problem_description).to eq "No description given\n\nRoom: Bathroom\n\nLast question: \"Is it?\" -> No"
       end
     end
 
@@ -60,10 +76,14 @@ RSpec.describe RepairParams do
           'callback_time' => {
             'callback_time' => ['morning'],
           },
+          'last_question' => {
+            'question' => 'Is it?',
+            'answer' => 'No',
+          },
         }
 
         expect(RepairParams.new(answers).problem_description)
-          .to eq "My bath is broken\n\nCallback requested: between 8am and midday"
+          .to eq "My bath is broken\n\nLast question: \"Is it?\" -> No\n\nCallback requested: between 8am and midday"
       end
 
       it 'includes the callback info if there was no description' do
@@ -74,10 +94,14 @@ RSpec.describe RepairParams do
           'callback_time' => {
             'callback_time' => ['morning'],
           },
+          'last_question' => {
+            'question' => 'Is it?',
+            'answer' => 'No',
+          },
         }
 
         expect(RepairParams.new(answers).problem_description)
-          .to eq "No description given\n\nCallback requested: between 8am and midday"
+          .to eq "No description given\n\nLast question: \"Is it?\" -> No\n\nCallback requested: between 8am and midday"
       end
     end
   end

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe CreateRepair do
         'room' => {
           'room' => 'Bathroom',
         },
+        'last_question' => {
+          'question' => 'Is it?',
+          'answer' => 'No',
+        },
       }
 
       service = CreateRepair.new(api: fake_api)
@@ -33,7 +37,7 @@ RSpec.describe CreateRepair do
       expect(fake_api).to have_received(:create_repair)
         .with(
           priority: 'N',
-          problemDescription: "My bath is broken\n\nRoom: Bathroom",
+          problemDescription: "My bath is broken\n\nRoom: Bathroom\n\nLast question: \"Is it?\" -> No",
           propertyReference: '00034713',
           contact: {
             name: 'Jo Bloggs',
@@ -69,6 +73,10 @@ RSpec.describe CreateRepair do
         'describe_repair' => {
           'description' => 'My bath is broken',
         },
+        'last_question' => {
+          'question' => 'Is it?',
+          'answer' => 'No',
+        },
       }
 
       service = CreateRepair.new(api: fake_api)
@@ -79,17 +87,7 @@ RSpec.describe CreateRepair do
 
   it 'posts a default description, if none was provided' do
     fake_api = instance_double('HackneyApi')
-    expect(fake_api).to receive(:create_repair)
-      .with(
-        priority: 'N',
-        problemDescription: 'No description given',
-        propertyReference: '00034713',
-        contact: {
-          name: 'Jo Bloggs',
-          telephoneNumber: '07900 123456',
-        }
-      )
-
+    allow(fake_api).to receive(:create_repair)
     fake_answers = {
       'address' => {
         'propertyReference' => '00034713',
@@ -103,10 +101,25 @@ RSpec.describe CreateRepair do
       'describe_repair' => {
         'description' => '',
       },
+      'last_question' => {
+        'question' => 'Is it?',
+        'answer' => 'No',
+      },
     }
 
     service = CreateRepair.new(api: fake_api)
     service.call(answers: fake_answers)
+
+    expect(fake_api).to have_received(:create_repair)
+      .with(
+        priority: 'N',
+        problemDescription: "No description given\n\nLast question: \"Is it?\" -> No",
+        propertyReference: '00034713',
+        contact: {
+          name: 'Jo Bloggs',
+          telephoneNumber: '07900 123456',
+        }
+      )
   end
 
   context 'when an SOR code was identified' do
@@ -129,6 +142,10 @@ RSpec.describe CreateRepair do
         'diagnosis' => {
           'sor_code' => '002034',
         },
+        'last_question' => {
+          'question' => 'Is it?',
+          'answer' => 'No',
+        },
       }
 
       service = CreateRepair.new(api: fake_api)
@@ -137,7 +154,7 @@ RSpec.describe CreateRepair do
       expect(fake_api).to have_received(:create_repair)
         .with(
           priority: 'N',
-          problemDescription: 'My bath is broken',
+          problemDescription: "My bath is broken\n\nLast question: \"Is it?\" -> No",
           propertyReference: '00034713',
           contact: {
             name: 'Alex Doe',
@@ -183,6 +200,10 @@ RSpec.describe CreateRepair do
         },
         'diagnosis' => {
           'sor_code' => '002034',
+        },
+        'last_question' => {
+          'question' => 'Is it?',
+          'answer' => 'No',
         },
       }
 

--- a/spec/services/question_saver_spec.rb
+++ b/spec/services/question_saver_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe QuestionSaver do
   describe '.save' do
     context 'when there is an SOR code on the question' do
       it 'persists form data to the selected answer store' do
-        fake_question = instance_double('Question', id: 'start')
+        fake_question = instance_double('Question', id: 'start', title: 'is it?')
         allow(fake_question).to receive(:answer_data).with('Yes').and_return('sor_code' => '012345')
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)
@@ -25,7 +25,7 @@ RSpec.describe QuestionSaver do
       end
 
       it 'returns true' do
-        fake_question = instance_double('Question', id: 'start')
+        fake_question = instance_double('Question', id: 'start', title: 'is it?')
         allow(fake_question).to receive(:answer_data).with('Yes').and_return('sor_code' => '012345')
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)
@@ -40,7 +40,7 @@ RSpec.describe QuestionSaver do
 
     context 'when there is a room on the question' do
       it 'persists form data to the selected answer store' do
-        fake_question = instance_double('Question', id: 'which_room')
+        fake_question = instance_double('Question', id: 'which_room', title: 'is it?')
         allow(fake_question).to receive(:answer_data).with('Kitchen').and_return({})
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)
@@ -56,6 +56,56 @@ RSpec.describe QuestionSaver do
           .with(
             :room,
             room: 'Kitchen',
+          )
+      end
+    end
+
+    context 'when the question is the last in the tree (explicit description)' do
+      it 'persists form data to the selected answer store' do
+        fake_question = instance_double('Question', id: 'broken_tap', title: 'Is your tap broken?')
+        allow(fake_question).to receive(:answer_data)
+          .with('Yes')
+          .and_return('text' => 'Yes', 'desc' => 'kitchen_problem')
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('QuestionForm',
+                                    valid?: true,
+                                    answer: 'Yes')
+
+        saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
+        saver.save(fake_form)
+
+        expect(fake_answer_store)
+          .to have_received(:store_selected_answers)
+          .with(
+            :last_question,
+            question: 'Is your tap broken?',
+            answer: 'Yes',
+          )
+      end
+    end
+
+    context 'when the question is the last in the tree (implicit description)' do
+      it 'persists form data to the selected answer store' do
+        fake_question = instance_double('Question', id: 'broken_tap', title: 'Is your tap broken?')
+        allow(fake_question).to receive(:answer_data)
+          .with('Yes')
+          .and_return('text' => 'Yes', 'sor_code' => '01234567') # No explicit next, desc or page, so must be the last
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('QuestionForm',
+                                    valid?: true,
+                                    answer: 'Yes')
+
+        saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
+        saver.save(fake_form)
+
+        expect(fake_answer_store)
+          .to have_received(:store_selected_answers)
+          .with(
+            :last_question,
+            question: 'Is your tap broken?',
+            answer: 'Yes',
           )
       end
     end


### PR DESCRIPTION
Identify these as being the ones with a 'desc' key (i.e. it's
explicitly the last question), or if it has no 'next' or 'page' (i.e.
it's implicitly the last question.

The fact that this is implicit feels fragile, but I guess it makes it
easier to write the questions.yml

Made last question mandatory because if it's not there then something
has gone really wrong. Unfortunately this results in a bunch of tests
failing, but I think that's more of a sign of our tests not being
specific enough.