### PR TITLE
(275) Leaseholders cannot report repairs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,5 +9,4 @@
 # Offense count: 4
 Metrics/AbcSize:
   Exclude:
-    - app/controllers/addresses_controller.rb
     - app/controllers/contact_details_with_callback_controller.rb

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -2,21 +2,16 @@ class AddressesController < ApplicationController
   def create
     @form = AddressForm.new(address_form_params)
 
-    if @form.address_isnt_here?
-      return redirect_to page_path('address_isnt_here')
-    end
-
     saver = AddressSaver.new(selected_answer_store: selected_answer_store)
 
-    if saver.save(@form) == :invalid
+    case saver.save(@form)
+    when :success
+      redirect_to address_success_path
+    when :not_found
+      redirect_to page_path('address_isnt_here')
+    when :invalid
       @address_search = AddressSearch.new(postcode: @form.postcode)
-      return render 'address_searches/create'
-    end
-
-    if RepairParams.new(selected_answer_store.selected_answers).diagnosed?
-      redirect_to contact_details_path
-    else
-      redirect_to contact_details_with_callback_path
+      render 'address_searches/create'
     end
   end
 
@@ -24,5 +19,13 @@ class AddressesController < ApplicationController
 
   def address_form_params
     params.require(:address_form).permit(:property_reference, :postcode)
+  end
+
+  def address_success_path
+    if RepairParams.new(selected_answer_store.selected_answers).diagnosed?
+      contact_details_path
+    else
+      contact_details_with_callback_path
+    end
   end
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -12,6 +12,8 @@ class AddressesController < ApplicationController
     when :invalid
       @address_search = AddressSearch.new(postcode: @form.postcode)
       render 'address_searches/create'
+    when :not_maintainable
+      redirect_to page_path('cannot_report_repair')
     end
   end
 

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -8,7 +8,7 @@ class AddressesController < ApplicationController
 
     saver = AddressSaver.new(selected_answer_store: selected_answer_store)
 
-    unless saver.save(@form)
+    if saver.save(@form) == :invalid
       @address_search = AddressSearch.new(postcode: @form.postcode)
       return render 'address_searches/create'
     end

--- a/app/services/address_saver.rb
+++ b/app/services/address_saver.rb
@@ -5,7 +5,9 @@ class AddressSaver
   end
 
   def save(form)
-    if form.valid?
+    if form.address_isnt_here?
+      :not_found
+    elsif form.valid?
       persist_answers(form)
       :success
     else

--- a/app/services/address_saver.rb
+++ b/app/services/address_saver.rb
@@ -7,11 +7,10 @@ class AddressSaver
   def save(form)
     if form.address_isnt_here?
       :not_found
-    elsif form.valid?
-      persist_answers(form)
-      :success
-    else
+    elsif !form.valid?
       :invalid
+    else
+      persist_answers(form)
     end
   end
 
@@ -19,6 +18,15 @@ class AddressSaver
 
   def persist_answers(form)
     address = @api.get_property(property_reference: form.property_reference)
-    @selected_answer_store.store_selected_answers('address', address)
+    if maintainable?(address)
+      @selected_answer_store.store_selected_answers('address', address)
+      :success
+    else
+      :not_maintainable
+    end
+  end
+
+  def maintainable?(address)
+    address.fetch('maintainable', true)
   end
 end

--- a/app/services/address_saver.rb
+++ b/app/services/address_saver.rb
@@ -7,9 +7,9 @@ class AddressSaver
   def save(form)
     if form.valid?
       persist_answers(form)
-      true
+      :success
     else
-      false
+      :invalid
     end
   end
 

--- a/app/views/pages/cannot_report_repair.html.haml
+++ b/app/views/pages/cannot_report_repair.html.haml
@@ -1,7 +1,7 @@
 = back_link
 
 %h1
-  We can't find your address
+  We can't report a repair for your address
 
 %p
   This might be because your home is not managed by Hackney Council.

--- a/spec/features/leaseholders_cannot_report_in_dwelling_repairs_spec.rb
+++ b/spec/features/leaseholders_cannot_report_in_dwelling_repairs_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.feature 'Leaseholders cannot report in-dwelling repairs' do
+  scenario 'after choosing their address, they see a message asking them to call the RCC' do
+    property = {
+      'propertyReference' => '00001234',
+      'address' => '5 Paloma Street',
+      'postcode' => 'N1 6NN',
+      'maintainable' => false,
+    }
+
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get)
+      .with('v1/properties?postcode=N1 6NN')
+      .and_return('results' => [property])
+    allow(fake_api).to receive(:get)
+      .with('v1/properties/00001234')
+      .and_return(property)
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    visit '/address-search'
+
+    fill_in 'Postcode', with: 'N1 6NN'
+    click_on 'Find my address'
+
+    choose_radio_button '5 Paloma Street'
+    click_on 'Continue'
+
+    expect(page).to have_content "We can't report a repair for your address"
+  end
+end

--- a/spec/services/address_saver_spec.rb
+++ b/spec/services/address_saver_spec.rb
@@ -97,5 +97,35 @@ RSpec.describe AddressSaver do
         expect(saver.save(fake_form)).to eq :not_found
       end
     end
+
+    context 'when the address is not maintainable' do
+      it 'does not persist the form data' do
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('AddressForm',
+                                    valid?: true,
+                                    address_isnt_here?: false,
+                                    property_reference: '01234567')
+        fake_api = instance_double('HackneyApi', get_property: { 'maintainable' => false })
+
+        saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+        saver.save(fake_form)
+
+        expect(fake_answer_store).to_not have_received(:store_selected_answers)
+      end
+
+      it 'returns :not_maintainable' do
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('AddressForm',
+                                    valid?: true,
+                                    address_isnt_here?: false,
+                                    property_reference: '01234567')
+        fake_api = instance_double('HackneyApi', get_property: { 'maintainable' => false })
+
+        saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+        expect(saver.save(fake_form)).to eq :not_maintainable
+      end
+    end
   end
 end

--- a/spec/services/address_saver_spec.rb
+++ b/spec/services/address_saver_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'app/services/address_saver'
+
+RSpec.describe AddressSaver do
+  describe '.save' do
+    it 'persists form data to the selected answer store' do
+      fake_answer_store = instance_double('SelectedAnswerStore')
+      allow(fake_answer_store).to receive(:store_selected_answers)
+      fake_form = instance_double('AddressForm',
+                                  valid?: true,
+                                  property_reference: '00123456')
+      fake_property = { property_reference: '00123456' }
+      fake_api = instance_double('HackneyApi', get_property: fake_property)
+
+      saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+      saver.save(fake_form)
+
+      expect(fake_answer_store)
+        .to have_received(:store_selected_answers)
+        .with(
+          'address',
+          fake_property,
+        )
+    end
+
+    it 'returns true' do
+      fake_answer_store = instance_double('SelectedAnswerStore')
+      allow(fake_answer_store).to receive(:store_selected_answers)
+      fake_form = instance_double('AddressForm',
+                                  valid?: true,
+                                  property_reference: '00123456')
+      fake_property = { property_reference: '00123456' }
+      fake_api = instance_double('HackneyApi', get_property: fake_property)
+
+      saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+      expect(saver.save(fake_form)).to eq true
+    end
+
+    context 'when the form is invalid' do
+      it 'does not persist the form data' do
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('AddressForm',
+                                    valid?: false,
+                                    property_reference: '')
+        fake_api = instance_double('HackneyApi')
+
+        saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+        saver.save(fake_form)
+
+        expect(fake_answer_store).to_not have_received(:store_selected_answers)
+      end
+
+      it 'returns false' do
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('AddressForm',
+                                    valid?: false,
+                                    property_reference: '')
+        fake_api = instance_double('HackneyApi')
+
+        saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+        expect(saver.save(fake_form)).to eq false
+      end
+    end
+  end
+end

--- a/spec/services/address_saver_spec.rb
+++ b/spec/services/address_saver_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AddressSaver do
         )
     end
 
-    it 'returns true' do
+    it 'returns :success' do
       fake_answer_store = instance_double('SelectedAnswerStore')
       allow(fake_answer_store).to receive(:store_selected_answers)
       fake_form = instance_double('AddressForm',
@@ -33,7 +33,7 @@ RSpec.describe AddressSaver do
       fake_api = instance_double('HackneyApi', get_property: fake_property)
 
       saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
-      expect(saver.save(fake_form)).to eq true
+      expect(saver.save(fake_form)).to eq :success
     end
 
     context 'when the form is invalid' do
@@ -51,7 +51,7 @@ RSpec.describe AddressSaver do
         expect(fake_answer_store).to_not have_received(:store_selected_answers)
       end
 
-      it 'returns false' do
+      it 'returns :invalid' do
         fake_answer_store = instance_double('SelectedAnswerStore')
         allow(fake_answer_store).to receive(:store_selected_answers)
         fake_form = instance_double('AddressForm',
@@ -60,7 +60,7 @@ RSpec.describe AddressSaver do
         fake_api = instance_double('HackneyApi')
 
         saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
-        expect(saver.save(fake_form)).to eq false
+        expect(saver.save(fake_form)).to eq :invalid
       end
     end
   end

--- a/spec/services/address_saver_spec.rb
+++ b/spec/services/address_saver_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AddressSaver do
       allow(fake_answer_store).to receive(:store_selected_answers)
       fake_form = instance_double('AddressForm',
                                   valid?: true,
+                                  address_isnt_here?: false,
                                   property_reference: '00123456')
       fake_property = { property_reference: '00123456' }
       fake_api = instance_double('HackneyApi', get_property: fake_property)
@@ -28,6 +29,7 @@ RSpec.describe AddressSaver do
       allow(fake_answer_store).to receive(:store_selected_answers)
       fake_form = instance_double('AddressForm',
                                   valid?: true,
+                                  address_isnt_here?: false,
                                   property_reference: '00123456')
       fake_property = { property_reference: '00123456' }
       fake_api = instance_double('HackneyApi', get_property: fake_property)
@@ -42,6 +44,7 @@ RSpec.describe AddressSaver do
         allow(fake_answer_store).to receive(:store_selected_answers)
         fake_form = instance_double('AddressForm',
                                     valid?: false,
+                                    address_isnt_here?: false,
                                     property_reference: '')
         fake_api = instance_double('HackneyApi')
 
@@ -56,11 +59,42 @@ RSpec.describe AddressSaver do
         allow(fake_answer_store).to receive(:store_selected_answers)
         fake_form = instance_double('AddressForm',
                                     valid?: false,
+                                    address_isnt_here?: false,
                                     property_reference: '')
         fake_api = instance_double('HackneyApi')
 
         saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
         expect(saver.save(fake_form)).to eq :invalid
+      end
+    end
+
+    context 'when the address could not be found' do
+      it 'does not persist the form data' do
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('AddressForm',
+                                    valid?: true,
+                                    address_isnt_here?: true,
+                                    property_reference: 'address_isnt_here')
+        fake_api = instance_double('HackneyApi')
+
+        saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+        saver.save(fake_form)
+
+        expect(fake_answer_store).to_not have_received(:store_selected_answers)
+      end
+
+      it 'returns :not_found' do
+        fake_answer_store = instance_double('SelectedAnswerStore')
+        allow(fake_answer_store).to receive(:store_selected_answers)
+        fake_form = instance_double('AddressForm',
+                                    valid?: true,
+                                    address_isnt_here?: true,
+                                    property_reference: 'address_isnt_here')
+        fake_api = instance_double('HackneyApi')
+
+        saver = AddressSaver.new(api: fake_api, selected_answer_store: fake_answer_store)
+        expect(saver.save(fake_form)).to eq :not_found
       end
     end
   end


### PR DESCRIPTION
The API 'get property' endpoint will shortly return a new `maintainable`
boolean.

When this is `false`, it is likely the property belongs to a leaseholder or
is a non-Hackney Council managed address.

In this case, redirect the user to a page telling them to call the Repairs
Contact Centre for further assistance.