### PR TITLE
(292) apply styles to error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -9,14 +9,14 @@
   <meta content="ie-edge" http-equiv="x-ua-compatible">
   <link href="https://fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet">
   <!--[if lt IE 9]>
-  <script src="html5shiv.js"></script>
-  <link rel="stylesheet" media="all" href="errors-ie8.css" />
+  <script src="/html5shiv.js"></script>
+  <link rel="stylesheet" media="all" href="/errors-ie8.css" />
   <![endif]-->
   <!--[if gt IE 8]>
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
   <![endif]-->
   <!--[if !IE]><!-->
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
   <!-- <![endif]-->
 </head>
 <body>

--- a/public/422.html
+++ b/public/422.html
@@ -9,14 +9,14 @@
   <meta content="ie-edge" http-equiv="x-ua-compatible">
   <link href="https://fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet">
   <!--[if lt IE 9]>
-  <script src="html5shiv.js"></script>
-  <link rel="stylesheet" media="all" href="errors-ie8.css" />
+  <script src="/html5shiv.js"></script>
+  <link rel="stylesheet" media="all" href="/errors-ie8.css" />
   <![endif]-->
   <!--[if gt IE 8]>
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
   <![endif]-->
   <!--[if !IE]><!-->
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
   <!-- <![endif]-->
 </head>
 <body>

--- a/public/500.html
+++ b/public/500.html
@@ -9,14 +9,14 @@
   <meta content="ie-edge" http-equiv="x-ua-compatible">
   <link href="https://fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet">
   <!--[if lt IE 9]>
-  <script src="html5shiv.js"></script>
-  <link rel="stylesheet" media="all" href="errors-ie8.css" />
+  <script src="/html5shiv.js"></script>
+  <link rel="stylesheet" media="all" href="/errors-ie8.css" />
   <![endif]-->
   <!--[if gt IE 8]>
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
   <![endif]-->
   <!--[if !IE]><!-->
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
   <!-- <![endif]-->
 </head>
 <body>


### PR DESCRIPTION
Rails was trying to load the styles and script for error pages through
the controller rather than from /public. Prefixing the references with a
'/' makes these references absolute rather than relative.