### PR TITLE
(292) Rack timeout on api handled as api error

### DIFF
--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -7,6 +7,7 @@ class JsonApi
   class ApiError < Error; end
   class InvalidResponseError < ApiError; end
   class ConnectionError < ApiError; end
+  class TimeoutError < ApiError; end
   class StatusBadRequestError < ApiError; end
   class StatusNotFoundError < ApiError; end
   class StatusServerError < ApiError; end
@@ -41,6 +42,8 @@ class JsonApi
     raise InvalidResponseError, e.message
   rescue Faraday::ConnectionFailed => e
     raise ConnectionError, e.message
+  rescue Rack::Timeout::RequestTimeoutException => e
+    raise TimeoutError, e.message
   end
 
   def raise_for_http_status(response)

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -12,8 +12,8 @@ class JsonApi
   class StatusServerError < ApiError; end
   class StatusUnexpectedError < ApiError; end
 
-  def initialize(api_config = {})
-    @connection = ConnectionBuilder.new.build(api_config)
+  def initialize(api_config = {}, logger = Rails.logger)
+    @connection = ConnectionBuilder.new.build(logger, api_config)
   end
 
   def get(path)
@@ -74,6 +74,7 @@ class JsonApi
 
   class ConnectionBuilder
     def build(
+      logger,
       api_root: ENV['HACKNEY_API_ROOT'],
       api_cert: ENV['PROXY_API_CERT'],
       api_key: ENV['PROXY_API_KEY']
@@ -85,17 +86,18 @@ class JsonApi
         ssl: ssl_options(
           cert: api_cert,
           key: api_key,
-        )
+        ),
+        logger: logger,
       )
     end
 
     private
 
-    def build_connection(root:, ssl:)
+    def build_connection(root:, ssl:, logger:)
       Faraday.new root, ssl: ssl do |conn|
         conn.adapter Faraday.default_adapter
         conn.response :json
-        conn.response :logger, Rails.logger, headers: true, bodies: true
+        conn.response :logger, logger, headers: true, bodies: true
       end
     end
 

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -3,6 +3,7 @@ require 'faraday_middleware'
 require 'app/queries/json_api'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/slice'
+require 'rack-timeout'
 require 'logger'
 require 'spec/support/test_ssl'
 
@@ -121,6 +122,17 @@ RSpec.describe JsonApi do
 
         expect { json_api.get('properties?postcode=A1 1AA') }
           .to raise_error(JsonApi::ConnectionError)
+      end
+    end
+
+    context 'when the request took too long' do
+      it 'raises an error' do
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+          .to_raise(Rack::Timeout::RequestTimeoutException)
+
+        expect { json_api.get('properties?postcode=A1 1AA') }
+          .to raise_error(JsonApi::TimeoutError)
       end
     end
 

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -3,9 +3,16 @@ require 'faraday_middleware'
 require 'app/queries/json_api'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/slice'
+require 'logger'
 require 'spec/support/test_ssl'
 
 RSpec.describe JsonApi do
+  before do
+    dev_null = File.new('/dev/null', 'w')
+    null_logger = Logger.new(dev_null)
+    stub_const('Rails', double(logger: null_logger))
+  end
+
   describe 'construction' do
     context 'when the api root is missing' do
       it 'raises an exception' do


### PR DESCRIPTION
If a Rack::Timeout error happens during an API call, handle it as an API
error so that we present the correct message to the user, not a generic
"something went wrong" message