### PR TITLE
(252) YouTube embeds don't overflow screen on mobile

### DIFF
--- a/app/assets/stylesheets/components/main.scss
+++ b/app/assets/stylesheets/components/main.scss
@@ -59,6 +59,12 @@ main {
     padding-bottom: 2em;
   }
 
+  object, embed {
+    height: 315px;
+    max-width: 95%;
+    width: 560px;
+  }
+
   abbr[title] {
     cursor: help;
     text-decoration: underline dotted;

--- a/app/views/pages/damp_and_mould.html.haml
+++ b/app/views/pages/damp_and_mould.html.haml
@@ -10,11 +10,11 @@
   Watch this short video for some advice on dealing
   with damp and mould problem areas in your home.
 
-%object{ height: '315', width: '560' }
+%object
   %param{ name: 'movie', value: 'https://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', src: 'https://www.youtube.com/v/7nq71pGBGI8?version=3&hl=en_US', type: 'application/x-shockwave-flash' }
 
 %p
   Select continue if you'd still like to report this repair.

--- a/app/views/pages/heating_repairs.html.haml
+++ b/app/views/pages/heating_repairs.html.haml
@@ -6,11 +6,11 @@
 %h2
   Watch this short video to find out how to fix common heating problems.
 
-%object{ height: '315', width: '560' }
+%object
   %param{ name: 'movie', value: 'https://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', src: 'https://www.youtube.com/v/ktklk7d0ibY?version=3&hl=en_US', type: 'application/x-shockwave-flash' }
 
 %p
   If your heating still isn't working, call our

--- a/app/views/pages/replace_lightbulb.html.haml
+++ b/app/views/pages/replace_lightbulb.html.haml
@@ -6,11 +6,11 @@
 %p
   Watch this short video for advice on how to replace a light bulb or a lamp in your home.
 
-%object{ height: '315', width: '560' }
+%object
   %param{ name: 'movie', value: 'https://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', src: 'https://www.youtube.com/v/NZN2AZAMPHY?version=3&hl=en_US', type: 'application/x-shockwave-flash' }
 
 %p
   If you've replaced the bulb and the light still isn't working, please select continue to book an appointment.

--- a/app/views/pages/toilet_unblock_info.html.haml
+++ b/app/views/pages/toilet_unblock_info.html.haml
@@ -6,11 +6,11 @@
 %p
   Watch this short video for advice on how to unblock a toilet in your home.
 
-%object{ height: '315', width: '560' }
+%object
   %param{ name: 'movie', value: 'https://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', src: 'https://www.youtube.com/v/_zzMhYpaD-o?version=3&hl=en_US', type: 'application/x-shockwave-flash' }
 
 %p
   If your toilet is still blocked, please

--- a/app/views/pages/unblock_sink.html.haml
+++ b/app/views/pages/unblock_sink.html.haml
@@ -6,11 +6,11 @@
 %p
   Watch this short video for advice on how to unblock a sink in your home.
 
-%object{ height: '315', width: '560' }
+%object
   %param{ name: 'movie', value: 'https://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US' }/
   %param{ name: 'allowFullScreen', value: 'true' }/
   %param{ name: 'allowscriptaccess', value: 'always' }/
-  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', height: '315', src: 'https://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US', type: 'application/x-shockwave-flash', width: '560' }
+  %embed{ allowfullscreen: 'true', allowscriptaccess: 'always', src: 'https://www.youtube.com/v/WTJQi7iBgiA?version=3&hl=en_US', type: 'application/x-shockwave-flash' }
 
 %p
   If your sink is still blocked, please


### PR DESCRIPTION
Whilst doing browser testing, we discovered that the changes made to support the YouTube video embed in IE8 caused them to overflow the edge of the page on mobile.

Now videos are displayed at the recommended size of 560px wide on desktop, but restricted to 100% width (if this is less than 560px) on mobile.

Tested on BrowserStack with IE8 / iPhone 7 (Safari) / Android (Chrome) and all seem to be working:

# Internet Explorer 8

![win7_ie_8 0](https://user-images.githubusercontent.com/3166/34726047-c452313e-f54a-11e7-8fce-54d2f361a1c0.jpg)

# iPhone 6 (Safari)

![ios_iphone-6_8 3_portrait](https://user-images.githubusercontent.com/3166/34726055-cbaecfaa-f54a-11e7-85db-45ecb4f23e60.jpg)
  