### PR TITLE
(261) Validate all static pages compile correctly

### DIFF
--- a/spec/features/users_can_visit_all_static_pages_spec.rb
+++ b/spec/features/users_can_visit_all_static_pages_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.feature 'Users can visit all static pages' do
+  scenario 'receiving a positive valid response' do
+    HighVoltage.page_ids.each do |id|
+      visit "/pages/#{id}"
+
+      expect(page).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Visit each static page in turn, and ensure they respond with an `HTTP 200`. Previously, an error crept into one of the page templates, and it wasn't noticed until a user flagged it.