### PR TITLE
(306) Users can be sent to One Account when our service is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The app should run successfully without these environment variables:
   its own, less friendly, error message. Defaults to 15 seconds.
 - `APPOINTMENT_LIMIT` - Set this to override the maximum number of appointments
   returned from the `AppointmentFetcher` service. Defaults to 15.
+- `ONE_ACCOUNT_URL` - Set this to override the URL that redirects users to One
+  Account in the event that Report a Repair is disabled (see feature flagging
+  below).
 
 #### Feature flagging
 

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -1,0 +1,21 @@
+class LandingPageController < ApplicationController
+  skip_before_action :check_service_status
+
+  def index
+    if service_disabled?
+      redirect_to one_account
+    else
+      redirect_to '/'
+    end
+  end
+
+  private
+
+  def service_disabled?
+    App.flipper.enabled?(:service_disabled)
+  end
+
+  def one_account
+    ENV.fetch('ONE_ACCOUNT_URL', 'https://myaccount.hackney.gov.uk/')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get '/landing', to: 'landing_page#index'
+
   get '/address-search', to: 'address_searches#index', as: 'address_search'
   post '/address-search', to: 'address_searches#create'
 

--- a/spec/features/users_are_sent_to_one_account_when_service_disabled_spec.rb
+++ b/spec/features/users_are_sent_to_one_account_when_service_disabled_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'Users visiting our landing page from hackney.gov.uk' do
+  scenario 'redirected to home page when service is enabled' do
+    visit '/landing'
+
+    expect(page.current_path).to eql '/'
+    expect(page).to have_content 'We provide housing and communal area repairs for council tenants'
+  end
+
+  scenario 'redirected to One Account, when service is disabled' do
+    App.flipper.enable(:service_disabled)
+
+    visit '/landing'
+
+    expect(page.current_url).to eql 'https://myaccount.hackney.gov.uk/'
+  end
+
+  scenario 'redirected to another URL, when service is disabled and ONE_ACCOUNT_URL is set' do
+    ClimateControl.modify(ONE_ACCOUNT_URL: 'https://exampleurl.com/') do
+      App.flipper.enable(:service_disabled)
+
+      visit '/landing'
+
+      expect(page.current_url).to eql 'https://exampleurl.com/'
+    end
+  end
+end


### PR DESCRIPTION
In order for us to test 'Report a Repair' in live, add a new route `/landing' that` can be linked to from the button on `https://hackney.gov.uk/report-a-repair`.

The normal behaviour is to immediately redirect the user to our root path, so they can begin using the service.

In the event that we have to disable our service for some reason (via the `service_disabled` feature flag we already have in place) `/landing` will instead redirect users to the existing One Account service.

Finally, in case One Account's URL is changed for some reason, I've added an optional `ONE_ACCOUNT_URL` environment variable. Setting this allows users to be sent to this URL instead.

This puts the control of the redirect back to One Account in our hands, so that it can be performed without requiring any changes to the main hackney.gov.uk web site.