### PR TITLE
(134) Add BETA banner to the top of all pages

### DIFF
--- a/app/assets/stylesheets/components/main.scss
+++ b/app/assets/stylesheets/components/main.scss
@@ -82,4 +82,17 @@ main {
     margin-top: 0;
     margin-bottom: $gutter;
   }
+
+  .beta-banner {
+    font-size: 80%;
+
+    small {
+      background-color: $hackney-green;
+      color: $white;
+      padding: 2px 4px;
+      margin-right: 4px;
+      text-transform: uppercase;
+      font-weight: bold;
+    }
+  }
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -41,6 +41,14 @@
       #content{ role: 'main' }
         - flash.each do |key, value|
           = content_tag :div, value, class: "flash flash-#{key}"
+
+        .beta-banner
+          %p
+            %small Beta
+            This is a new service -
+            %a{ href: '/pages/beta' }
+              find out what this means
+
         = yield
 
     %footer

--- a/app/views/pages/beta.html.haml
+++ b/app/views/pages/beta.html.haml
@@ -1,0 +1,31 @@
+= back_link
+
+%h1
+  Beta on hackney.gov.uk
+
+%p
+  The ‘beta’ label means you’re looking at the first version of a new service or web page.
+
+%h2
+  Beta services
+
+%p
+  We regularly launch new or redesigned digital services. During the beta phase services
+  are continually tested and improved.
+
+%p
+  The beta label is displayed on a new service to show it’s being tested - it may not
+  work for everyone.
+
+%p
+  Redesigned services should be easier to use than the services they replace.
+
+%p
+  Sometimes a beta service will be available at the same time as an older,
+  existing service - you can choose which one to use.
+
+%p
+  Successful beta services eventually become ‘live’ and replace any older services
+  that perform the same task.
+
+


### PR DESCRIPTION
This follows the pattern used by GOV.UK, and includes a link to a static page which explains to users what a 'beta' service is.

I've taken the copy directly from the GOV.UK guidance, with some minor renames.

---
![beta-banner](https://user-images.githubusercontent.com/3166/36024647-453c469a-0d88-11e8-91be-f8c66fc0dc2b.png)
