### PR TITLE
(309) Hide the 'beta' banner when the site is disabled

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,12 +42,13 @@
         - flash.each do |key, value|
           = content_tag :div, value, class: "flash flash-#{key}"
 
-        .beta-banner
-          %p
-            %small Beta
-            This is a new service -
-            %a{ href: '/pages/beta' }
-              find out what this means
+        - unless App.flipper.enabled?(:service_disabled)
+          .beta-banner
+            %p
+              %small Beta
+              This is a new service -
+              %a{ href: '/pages/beta' }
+                find out what this means
 
         = yield
 

--- a/spec/features/users_know_service_is_in_beta_spec.rb
+++ b/spec/features/users_know_service_is_in_beta_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.feature 'Users know the site is in beta' do
+  scenario 'when the site is enabled, a beta banner is displayed' do
+    visit '/'
+
+    expect(page).to have_content 'This is a new service'
+  end
+
+  scenario 'when the site is disabled, beta banner is hidden' do
+    App.flipper.enable(:service_disabled)
+
+    visit '/'
+
+    expect(page).not_to have_content 'This is a new service'
+  end
+end


### PR DESCRIPTION
Disabling the site replaces all pages with a warning that the service is unavailable. Unfortunately, the beta banner's link would be broken in this case.

I've therefore removed the beta banner from all pages when the service is disabled.