### PR TITLE
(308) Allow landing page bouncing to be controlled separately

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -2,7 +2,7 @@ class LandingPageController < ApplicationController
   skip_before_action :check_service_status
 
   def index
-    if service_disabled?
+    if bouncing?
       redirect_to one_account
     else
       redirect_to '/'
@@ -11,8 +11,8 @@ class LandingPageController < ApplicationController
 
   private
 
-  def service_disabled?
-    App.flipper.enabled?(:service_disabled)
+  def bouncing?
+    App.flipper.enabled?(:bounce_to_one_account)
   end
 
   def one_account

--- a/spec/features/users_are_sent_to_one_account_when_bouncing_enabled_spec.rb
+++ b/spec/features/users_are_sent_to_one_account_when_bouncing_enabled_spec.rb
@@ -1,24 +1,24 @@
 require 'rails_helper'
 
 RSpec.feature 'Users visiting our landing page from hackney.gov.uk' do
-  scenario 'redirected to home page when service is enabled' do
+  scenario 'redirected to home page when bouncing is disabled' do
     visit '/landing'
 
     expect(page.current_path).to eql '/'
     expect(page).to have_content 'We provide housing and communal area repairs for council tenants'
   end
 
-  scenario 'redirected to One Account, when service is disabled' do
-    App.flipper.enable(:service_disabled)
+  scenario 'redirected to One Account, when bouncing is enabled' do
+    App.flipper.enable(:bounce_to_one_account)
 
     visit '/landing'
 
     expect(page.current_url).to eql 'https://myaccount.hackney.gov.uk/'
   end
 
-  scenario 'redirected to another URL, when service is disabled and ONE_ACCOUNT_URL is set' do
+  scenario 'redirected to another URL, when bouncing is enabled and ONE_ACCOUNT_URL is set' do
     ClimateControl.modify(ONE_ACCOUNT_URL: 'https://exampleurl.com/') do
-      App.flipper.enable(:service_disabled)
+      App.flipper.enable(:bounce_to_one_account)
 
       visit '/landing'
 


### PR DESCRIPTION
Previously, the behaviour of the redirect on '/launch' was linked to the `service_disabled` feature flag. This would prevent testing the site in production after the link on hackney.gov.uk goes live.

Now, you can redirect users back to the One Account via `/launch`, whilst allowing the service to be tested independently.