### PR TITLE
(310) Show non-best slots if no best slots are available

### DIFF
--- a/app/services/appointment_fetcher.rb
+++ b/app/services/appointment_fetcher.rb
@@ -3,8 +3,12 @@ class AppointmentFetcher
     @work_order_reference = work_order_reference
 
     appointments = filter_before_tomorrow(available_appointments)
-    appointments = keep_best_slots_only(appointments)
     appointments = filter_long_slots(appointments)
+
+    if best_slots?(appointments)
+      appointments = keep_best_slots_only(appointments)
+    end
+
     appointments.take(limit)
   end
 
@@ -38,5 +42,9 @@ class AppointmentFetcher
     appointments.select do |appointment|
       appointment.fetch('bestSlot') == true
     end
+  end
+
+  def best_slots?(appointments)
+    appointments.any? { |appointment| appointment.fetch('bestSlot') == true }
   end
 end

--- a/spec/services/appointment_fetcher_spec.rb
+++ b/spec/services/appointment_fetcher_spec.rb
@@ -91,6 +91,21 @@ RSpec.describe AppointmentFetcher do
     end
   end
 
+  it 'returns non-best slots if there are no best slots' do
+    non_best_slot = { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => false }
+
+    stub_appointments([non_best_slot])
+
+    travel_to Time.zone.local(2017, 10, 1) do
+      appointments = AppointmentFetcher.new.call(
+        work_order_reference: '1234',
+        limit: 2
+      )
+
+      expect(appointments).to include non_best_slot
+    end
+  end
+
   private
 
   def stub_appointments(appointments)


### PR DESCRIPTION
Whilst testing, we were offered *no* appointment slots because no 'best' slots are available. This change shows non-best slots in this case instead. 