### PR TITLE
(298) BUG - key not found 'last_question'

### DIFF
--- a/app/services/question_saver.rb
+++ b/app/services/question_saver.rb
@@ -40,19 +40,11 @@ class QuestionSaver
 
   def persist_last_question(form)
     answer = @question.answer_data(form.answer)
-    return unless last_question?(answer)
+
     @selected_answer_store.store_selected_answers(
       :last_question,
       question: @question.title,
       answer: answer['text']
     )
-  end
-
-  def last_question?(answer)
-    answer['desc'] || !explicit_redirect?(answer)
-  end
-
-  def explicit_redirect?(answer)
-    %w[desc next page].any? { |key| answer.key?(key) }
   end
 end

--- a/spec/services/question_saver_spec.rb
+++ b/spec/services/question_saver_spec.rb
@@ -60,86 +60,27 @@ RSpec.describe QuestionSaver do
       end
     end
 
-    context 'when the question is the last in the tree (explicit description)' do
-      it 'persists form data to the selected answer store' do
-        fake_question = instance_double('Question', id: 'broken_tap', title: 'Is your tap broken?')
-        allow(fake_question).to receive(:answer_data)
-          .with('Yes')
-          .and_return('text' => 'Yes', 'desc' => 'kitchen_problem')
-        fake_answer_store = instance_double('SelectedAnswerStore')
-        allow(fake_answer_store).to receive(:store_selected_answers)
-        fake_form = instance_double('QuestionForm',
-                                    valid?: true,
-                                    answer: 'Yes')
+    it 'persists the latest question and answer to the selected answer store' do
+      fake_question = instance_double('Question', id: 'broken_tap', title: 'Is your tap broken?')
+      allow(fake_question).to receive(:answer_data)
+        .with('Yes')
+        .and_return('text' => 'Yes', 'desc' => 'kitchen_problem')
+      fake_answer_store = instance_double('SelectedAnswerStore')
+      allow(fake_answer_store).to receive(:store_selected_answers)
+      fake_form = instance_double('QuestionForm',
+                                  valid?: true,
+                                  answer: 'Yes')
 
-        saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
-        saver.save(fake_form)
+      saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
+      saver.save(fake_form)
 
-        expect(fake_answer_store)
-          .to have_received(:store_selected_answers)
-          .with(
-            :last_question,
-            question: 'Is your tap broken?',
-            answer: 'Yes',
-          )
-      end
-    end
-
-    context 'when the question is the last in the tree (implicit description)' do
-      it 'persists form data to the selected answer store' do
-        fake_question = instance_double('Question', id: 'broken_tap', title: 'Is your tap broken?')
-        allow(fake_question).to receive(:answer_data)
-          .with('Yes')
-          .and_return('text' => 'Yes', 'sor_code' => '01234567') # No explicit next, desc or page, so must be the last
-        fake_answer_store = instance_double('SelectedAnswerStore')
-        allow(fake_answer_store).to receive(:store_selected_answers)
-        fake_form = instance_double('QuestionForm',
-                                    valid?: true,
-                                    answer: 'Yes')
-
-        saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
-        saver.save(fake_form)
-
-        expect(fake_answer_store)
-          .to have_received(:store_selected_answers)
-          .with(
-            :last_question,
-            question: 'Is your tap broken?',
-            answer: 'Yes',
-          )
-      end
-    end
-
-    context 'when there is no SOR code on the question' do
-      it "doesn't change the selected answer store" do
-        fake_question = instance_double('Question', id: 'start')
-        allow(fake_question).to receive(:answer_data).with('Yes').and_return('next' => 'suggested_countermeasures')
-        fake_answer_store = instance_double('SelectedAnswerStore')
-        allow(fake_answer_store).to receive(:store_selected_answers)
-        fake_form = instance_double('QuestionForm',
-                                    valid?: true,
-                                    answer: 'Yes')
-
-        saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
-        saver.save(fake_form)
-
-        expect(fake_answer_store).to_not have_received(:store_selected_answers)
-      end
-
-      it 'returns true' do
-        # ...because even though we're not doing anything, it's not a failure
-        # and the caller shouldn't have to care
-        fake_question = instance_double('Question', id: 'start')
-        allow(fake_question).to receive(:answer_data).with('Yes').and_return('next' => 'suggested_countermeasures')
-        fake_answer_store = instance_double('SelectedAnswerStore')
-        allow(fake_answer_store).to receive(:store_selected_answers)
-        fake_form = instance_double('QuestionForm',
-                                    valid?: true,
-                                    answer: 'Yes')
-
-        saver = QuestionSaver.new(question: fake_question, selected_answer_store: fake_answer_store)
-        expect(saver.save(fake_form)).to eq true
-      end
+      expect(fake_answer_store)
+        .to have_received(:store_selected_answers)
+        .with(
+          :last_question,
+          question: 'Is your tap broken?',
+          answer: 'Yes',
+        )
     end
 
     context 'when the form is invalid' do


### PR DESCRIPTION
I've fixed this bug by always saving the current question and answer to the `last_question` key in the session, instead of using logic to try and only write to this key when we reach a leaf node in the decision tree, which didn't always work properly.