### PR TITLE
(316) Don't make excessive API calls

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -26,11 +26,7 @@ class AppointmentsController < ApplicationController
   end
 
   def work_order_reference
-    Repair.new(
-      HackneyApi.new.get_repair(
-        repair_request_reference: params[:repair_request_reference]
-      )
-    ).work_order_reference
+    repair.work_order_reference
   end
 
   def available_appointments
@@ -52,6 +48,14 @@ class AppointmentsController < ApplicationController
 
     selected_answer_store.store_selected_answers(
       'appointment', appointment
+    )
+  end
+
+  def repair
+    @repair ||= Repair.new(
+      HackneyApi.new.get_repair(
+        repair_request_reference: params[:repair_request_reference]
+      )
     )
   end
 end

--- a/app/presenters/confirmation.rb
+++ b/app/presenters/confirmation.rb
@@ -8,10 +8,6 @@ class Confirmation
   end
 
   def request_reference
-    repair = Repair.new(
-      @api.get_repair(repair_request_reference: @request_reference)
-    )
-
     repair.work_order_reference || repair.request_reference
   end
 
@@ -51,5 +47,11 @@ class Confirmation
 
   def format_telephone_number(number)
     number.delete("\s")
+  end
+
+  def repair
+    @repair ||= Repair.new(
+      @api.get_repair(repair_request_reference: @request_reference)
+    )
   end
 end


### PR DESCRIPTION
In a couple of places, we needed either the `repair_request_reference` or `work_order_reference` for the newly created repair. Memoise the call to `HackneyApi#get_repair` so that we re-use the response rather than requesting it multiple times.