### PR TITLE
Add message for no available appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -3,6 +3,12 @@ class AppointmentsController < ApplicationController
     @form = AppointmentForm.new
     @appointments = available_appointments
     @work_order_reference = work_order_reference
+
+    if @appointments.any?
+      render :show
+    else
+      render :none_available
+    end
   end
 
   def submit

--- a/app/views/appointments/none_available.html.haml
+++ b/app/views/appointments/none_available.html.haml
@@ -1,0 +1,24 @@
+.grid-row
+  %section#confirmation.column-two-thirds
+    %h1
+      Booking your appointment
+
+    %p
+      Sorry, we can't book an appointment for you online right now.
+
+    .box-highlight.lede
+      Your reference number is
+      = succeed "." do
+        %strong= @work_order_reference
+
+    %p
+      %strong
+        Please call us on
+        = repairs_contact_centre_telephone_number
+        to arrange an appointment
+      and quote your reference number
+      = succeed "." do
+        %strong= @work_order_reference
+      We’re open
+      = succeed '.' do
+        = t('rcc_opening_hours')

--- a/app/views/errors/_contact_phone_numbers.html.haml
+++ b/app/views/errors/_contact_phone_numbers.html.haml
@@ -3,8 +3,9 @@
     Please phone us on
     = succeed '.' do
       = repairs_contact_centre_telephone_number
-    We’re open Monday to Friday from 8am to midnight and on Saturday
-    from 9am to 1pm.
+    We’re open
+    = succeed '.' do
+      = t('rcc_opening_hours')
     You can phone us outside these hours if you need an emergency repair.
 
 %p

--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.feature 'Residents see a useful message when no appointments available' do
+  scenario 'when the API returns no available appointments' do
+    property = {
+      'propertyReference' => '00000503',
+      'address' => 'Ross Court 23',
+      'postcode' => 'E5 8TE',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:post)
+      .with('v1/repairs', anything)
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+        'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ]
+      )
+    allow(fake_api).to receive(:get)
+      .with('v1/repairs/00367923')
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+        'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ]
+      )
+    allow(fake_api).to receive(:get)
+      .with('v1/work_orders/09124578/available_appointments')
+      .and_return(
+        'results' => []
+      )
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    fake_question_set = instance_double(QuestionSet)
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('which_room')
+      .and_return(
+        Question.new(
+          'id' => 'which_room',
+          'question' => 'Which room?',
+          'answers' => [
+            { 'text' => 'Kitchen', 'next' => 'kitchen' },
+            { 'text' => 'Bathroom' },
+            { 'text' => 'Other' },
+          ],
+        )
+      )
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('kitchen')
+      .and_return(
+        Question.new(
+          'id' => 'kitchen',
+          'question' => 'Is your tap broken?',
+          'answers' => [
+            { 'text' => 'Yes', 'sor_code' => '0078965', 'desc' => 'kitchen_problem' },
+            { 'text' => 'No' },
+          ],
+        )
+      )
+    allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Kitchen'
+    click_on 'Continue'
+
+    choose_radio_button 'Yes'
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E5 8TE'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Ross Court 23'
+    click_on 'Continue'
+
+    # Contact details:
+    fill_in 'Full name', with: 'John Evans'
+    fill_in 'Telephone number', with: '078 98765 432'
+    click_on 'Continue'
+
+    aggregate_failures do
+      expect(page).to have_content 'Please call us on 020 8356 3691 to arrange an appointment'
+      expect(page).to have_content 'Your reference number is 09124578'
+    end
+
+    expect(fake_api).to have_received(:post).with(
+      'v1/repairs',
+      priority: 'N',
+      problemDescription: "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+      propertyReference: '00000503',
+      contact: {
+        name: 'John Evans',
+        telephoneNumber: '078 98765 432',
+      },
+      workOrders: [
+        { sorCode: '0078965' },
+      ]
+    )
+  end
+end


### PR DESCRIPTION
The API will try to find some appointments available in the next 4 weeks - if it can't, it will return an empty list. For that case we want to show the resident a useful page, rather than asking them to pick an appointment from a list of none.

Hopefully this page will never appear in LIVE, as there should always be some available appointments within the month, but if it does it needs to be useful for the resident using it.

The page looks like this:

<img width="902" alt="screen shot 2018-02-23 at 15 30 10" src="https://user-images.githubusercontent.com/74812/36602078-f21f557e-18ae-11e8-9096-4672cd2b66f5.png">