### PR TITLE
Update failing rspec feature

### DIFF
--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
-        'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+        'problem' => "Room: Kitchen\n\nMy sink is blocked",
         'propertyReference' => '00000503',
         'workOrders' => [
           {
@@ -29,7 +29,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
-        'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+        'problem' => "Room: Kitchen\n\nMy sink is blocked",
         'propertyReference' => '00000503',
         'workOrders' => [
           {
@@ -114,7 +114,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
     expect(fake_api).to have_received(:post).with(
       'v1/repairs',
       priority: 'N',
-      problemDescription: "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+      problemDescription: "Room: Kitchen\n\nMy sink is blocked",
       propertyReference: '00000503',
       contact: {
         name: 'John Evans',


### PR DESCRIPTION
When the no-appointments screen was added it was based off a commit that didn't include the problem description updates. The spec worked fine on its own branch, but once it got merged into `develop` it failed because the description generated by the app had changed.

This updates the expectations inline with the new description format.