### PR TITLE
Remove callback "within one working day" promise

### DIFF
--- a/app/views/confirmations/_callback.html.haml
+++ b/app/views/confirmations/_callback.html.haml
@@ -1,5 +1,5 @@
 %p
-  We will call you within one working day, between
+  We will call you between
   %strong= callback.time
   to arrange a repair appointment.
 

--- a/app/views/contact_details_with_callback/index.html.haml
+++ b/app/views/contact_details_with_callback/index.html.haml
@@ -5,7 +5,7 @@
     %legend.question
       %h1= t('contact-details.title')
 
-      %p We will contact you within one working day to book an appointment for your repair.
+      %p We will contact you to book an appointment for your repair.
 
     .answers
       = f.input :full_name

--- a/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
+++ b/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
@@ -138,6 +138,6 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
     choose_radio_button 'morning (8am to midday)'
     click_on 'Continue'
 
-    expect(page).to have_content 'We will call you within one working day, between 8am and midday'
+    expect(page).to have_content 'We will call you between 8am and midday'
   end
 end


### PR DESCRIPTION
Remove the timeframe promised for the callback after discussion with the RCC. We can revisit the promised timeframe in the future once we understand the impact of the service.