### PR TITLE
Change Hackney API URLs

### DIFF
--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -4,32 +4,32 @@ class HackneyApi
   end
 
   def list_properties(postcode:)
-    response = @json_api.get('v1/properties?postcode=' + postcode)
+    response = @json_api.get('hackneyrepairs/properties?postcode=' + postcode)
     response.fetch('results')
   end
 
   def get_property(property_reference:)
-    @json_api.get('v1/properties/' + property_reference)
+    @json_api.get('hackneyrepairs/properties/' + property_reference)
   end
 
   def create_repair(repair_params)
-    @json_api.post('v1/repairs', repair_params)
+    @json_api.post('hackneyrepairs/repairs', repair_params)
   end
 
   def get_repair(repair_request_reference:)
-    @json_api.get('v1/repairs/' + repair_request_reference)
+    @json_api.get('hackneyrepairs/repairs/' + repair_request_reference)
   end
 
   def list_available_appointments(work_order_reference:)
     response = @json_api.get(
-      'v1/work_orders/' + work_order_reference + '/available_appointments'
+      'hackneyrepairs/work_orders/' + work_order_reference + '/available_appointments'
     )
     response.fetch('results')
   end
 
   def book_appointment(work_order_reference:, begin_date:, end_date:)
     @json_api.post(
-      'v1/work_orders/' + work_order_reference + '/appointments',
+      'hackneyrepairs/work_orders/' + work_order_reference + '/appointments',
       beginDate: begin_date,
       endDate: end_date
     )

--- a/spec/features/leaseholders_cannot_report_in_dwelling_repairs_spec.rb
+++ b/spec/features/leaseholders_cannot_report_in_dwelling_repairs_spec.rb
@@ -11,10 +11,10 @@ RSpec.feature 'Leaseholders cannot report in-dwelling repairs' do
 
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get)
-      .with('v1/properties?postcode=N1 6NN')
+      .with('hackneyrepairs/properties?postcode=N1 6NN')
       .and_return('results' => [property])
     allow(fake_api).to receive(:get)
-      .with('v1/properties/00001234')
+      .with('hackneyrepairs/properties/00001234')
       .and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -22,8 +22,8 @@ RSpec.feature 'Resident can locate a problem' do
     matching_properties = [other_property, tenant_property]
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => matching_properties)
-    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(tenant_property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=N1 6NU').and_return('results' => matching_properties)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/abc123').and_return(tenant_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -46,7 +46,7 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'when the address search returned no results' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=N1 6NU').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -83,8 +83,8 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'changing the postcode after searching' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6AA').and_return('results' => [])
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=N1 6AA').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=N1 6NU').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -110,7 +110,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [matching_property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=N1 6NU').and_return('results' => [matching_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -132,7 +132,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=N1 6NU').and_return('results' => [other_property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=N1 6NU').and_return('results' => [other_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(question: 'What is the problem?', answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])
@@ -64,8 +64,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(question: 'What is the problem?', answers: [{ 'text' => 'skip' }])
@@ -152,8 +152,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])
@@ -200,8 +200,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -260,7 +260,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -294,7 +294,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'going back from the address selection page' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E8 5TQ').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E8 5TQ').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -15,10 +15,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'postcode' => 'E5 8TE',
       }
       fake_api = instance_double(JsonApi)
-      allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
-      allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
+      allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E5 8TE').and_return('results' => [property])
+      allow(fake_api).to receive(:get).with('hackneyrepairs/properties/00000503').and_return(property)
       allow(fake_api).to receive(:post)
-        .with('v1/repairs', anything)
+        .with('hackneyrepairs/repairs', anything)
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
@@ -32,7 +32,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           ]
         )
       allow(fake_api).to receive(:get)
-        .with('v1/repairs/00367923')
+        .with('hackneyrepairs/repairs/00367923')
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
@@ -46,7 +46,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           ]
         )
       allow(fake_api).to receive(:get)
-        .with('v1/work_orders/09124578/available_appointments')
+        .with('hackneyrepairs/work_orders/09124578/available_appointments')
         .and_return(
           'results' => [
             { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true },
@@ -55,7 +55,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         )
       allow(fake_api).to receive(:post)
         .with(
-          'v1/work_orders/09124578/appointments',
+          'hackneyrepairs/work_orders/09124578/appointments',
           beginDate: '2017-10-11T12:00:00Z',
           endDate: '2017-10-11T17:00:00Z',
         )
@@ -146,7 +146,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       end
 
       expect(fake_api).to have_received(:post).with(
-        'v1/repairs',
+        'hackneyrepairs/repairs',
         priority: 'N',
         problemDescription: "Room: Kitchen\n\nMy sink is blocked",
         propertyReference: '00000503',
@@ -160,7 +160,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       )
 
       expect(fake_api).to have_received(:post).with(
-        'v1/work_orders/09124578/appointments',
+        'hackneyrepairs/work_orders/09124578/appointments',
         beginDate: '2017-10-11T12:00:00Z',
         endDate: '2017-10-11T17:00:00Z',
       )
@@ -174,10 +174,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('v1/repairs', anything)
+      .with('hackneyrepairs/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -185,7 +185,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
-      .with('v1/repairs/00367923')
+      .with('hackneyrepairs/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -255,7 +255,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'v1/repairs',
+      'hackneyrepairs/repairs',
       priority: 'N',
       problemDescription: "Callback requested: between 8am and 5pm\n\nMy sink is blocked",
       propertyReference: '00000503',

--- a/spec/features/residents_see_nice_errors_spec.rb
+++ b/spec/features/residents_see_nice_errors_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Error pages' do
     fake_api = instance_double(JsonApi)
     connection_error = JsonApi::ConnectionError.new('Failed to open TCP connection to api_server:8000 (getaddrinfo: nodename nor servname provided, or not known)')
     allow(fake_api).to receive(:get)
-      .with('v1/properties?postcode=E5 8TE')
+      .with('hackneyrepairs/properties?postcode=E5 8TE')
       .and_raise connection_error
     allow(JsonApi).to receive(:new).and_return(fake_api)
 

--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -8,10 +8,10 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('v1/repairs', anything)
+      .with('hackneyrepairs/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -25,7 +25,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
         ]
       )
     allow(fake_api).to receive(:get)
-      .with('v1/repairs/00367923')
+      .with('hackneyrepairs/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -39,7 +39,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
         ]
       )
     allow(fake_api).to receive(:get)
-      .with('v1/work_orders/09124578/available_appointments')
+      .with('hackneyrepairs/work_orders/09124578/available_appointments')
       .and_return(
         'results' => []
       )
@@ -112,7 +112,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'v1/repairs',
+      'hackneyrepairs/repairs',
       priority: 'N',
       problemDescription: "Room: Kitchen\n\nMy sink is blocked",
       propertyReference: '00000503',

--- a/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
+++ b/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
@@ -9,13 +9,13 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get)
-      .with('v1/properties?postcode=E5 8TE')
+      .with('hackneyrepairs/properties?postcode=E5 8TE')
       .and_return('results' => [property])
     allow(fake_api).to receive(:get)
-      .with('v1/properties/00000512')
+      .with('hackneyrepairs/properties/00000512')
       .and_return(property)
     allow(fake_api).to receive(:post)
-      .with('v1/repairs', anything)
+      .with('hackneyrepairs/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -29,7 +29,7 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
         ],
       )
     allow(fake_api).to receive(:get)
-      .with('v1/repairs/00367923')
+      .with('hackneyrepairs/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'orderReference' => '09124578',
@@ -44,7 +44,7 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
         ],
       )
     allow(fake_api).to receive(:get)
-      .with('v1/work_orders/09124578/available_appointments')
+      .with('hackneyrepairs/work_orders/09124578/available_appointments')
       .and_return(
         'results' => [
           {
@@ -55,7 +55,7 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
         ]
       )
     allow(fake_api).to receive(:post)
-      .with('v1/work_orders/09124578/appointments', anything)
+      .with('hackneyrepairs/work_orders/09124578/appointments', anything)
       .and_return(
         'beginDate' => '2017-11-27T10:00:00Z',
         'endDate' => '2017-11-27T12:00:00Z'

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -9,8 +9,8 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
-    allow(fake_api).to receive(:get).with('v1/properties/zzz').and_return(matching_property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E5 8TE').and_return('results' => [matching_property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -67,8 +67,8 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
-    allow(fake_api).to receive(:get).with('v1/properties/zzz').and_return(matching_property)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties?postcode=E5 8TE').and_return('results' => [matching_property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => 'fake_code' }])

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -33,7 +33,7 @@ describe HackneyApi do
         'postcode' => 'N1 1AA',
       }
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:get).with('v1/properties/cre045').and_return(results)
+      allow(json_api).to receive(:get).with('hackneyrepairs/properties/cre045').and_return(results)
       api = HackneyApi.new(json_api)
 
       expect(api.get_property(property_reference: 'cre045')).to eql results
@@ -43,7 +43,7 @@ describe HackneyApi do
   describe '#create_repair' do
     it 'sends repair creation parameters' do
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:post).with('v1/repairs', anything)
+      allow(json_api).to receive(:post).with('hackneyrepairs/repairs', anything)
 
       api = HackneyApi.new(json_api)
       repair_params = {
@@ -55,7 +55,7 @@ describe HackneyApi do
 
       expect(json_api).to have_received(:post)
         .with(
-          'v1/repairs',
+          'hackneyrepairs/repairs',
           priority: 'U',
           problemDescription: 'It is broken',
           propertyReference: '01234567',
@@ -66,7 +66,7 @@ describe HackneyApi do
       json_api = instance_double('JsonApi')
       result = double('api result')
       allow(json_api).to receive(:post)
-        .with('v1/repairs', anything)
+        .with('hackneyrepairs/repairs', anything)
         .and_return result
 
       api = HackneyApi.new(json_api)
@@ -89,7 +89,7 @@ describe HackneyApi do
         ],
       }
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:get).with('v1/repairs/00045678').and_return(result)
+      allow(json_api).to receive(:get).with('hackneyrepairs/repairs/00045678').and_return(result)
       api = HackneyApi.new(json_api)
 
       expect(api.get_repair(repair_request_reference: '00045678')).to eql result
@@ -113,7 +113,7 @@ describe HackneyApi do
 
       json_api = instance_double('JsonApi')
       result = { 'results' => appointments }
-      allow(json_api).to receive(:get).with('v1/work_orders/00412371/available_appointments').and_return(result)
+      allow(json_api).to receive(:get).with('hackneyrepairs/work_orders/00412371/available_appointments').and_return(result)
       api = HackneyApi.new(json_api)
 
       expect(api.list_available_appointments(work_order_reference: '00412371')).to eql appointments
@@ -131,7 +131,7 @@ describe HackneyApi do
       allow(json_api)
         .to receive(:post)
         .with(
-          'v1/work_orders/00412371/appointments',
+          'hackneyrepairs/work_orders/00412371/appointments',
           beginDate: '2017-11-01T14:00:00Z',
           endDate: '2017-11-01T16:30:00Z'
         )

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -282,11 +282,11 @@ RSpec.describe JsonApi do
           api_cert: TestSsl.certificate,
           api_key: TestSsl.key,
         )
-        stub_request(:get, 'http://hackney.api:8000/v1/repairs/00012345')
+        stub_request(:get, 'http://hackney.api:8000/hackneyrepairs/repairs/00012345')
 
-        json_api.get('v1/repairs/00012345')
+        json_api.get('hackneyrepairs/repairs/00012345')
 
-        expect(a_request(:get, 'http://hackney.api:8000/v1/repairs/00012345'))
+        expect(a_request(:get, 'http://hackney.api:8000/hackneyrepairs/repairs/00012345'))
           .to have_been_made.once
       end
     end
@@ -297,12 +297,12 @@ RSpec.describe JsonApi do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       request_params = { priority: 'N', problemDescription: 'It is broken', propertyReference: '00001234' }
       request_json = request_params.to_json
-      stub_request(:post, 'http://hackney.api:8000/v1/repairs')
+      stub_request(:post, 'http://hackney.api:8000/hackneyrepairs/repairs')
         .with(body: request_json)
 
-      json_api.post('v1/repairs', request_params)
+      json_api.post('hackneyrepairs/repairs', request_params)
 
-      expect(a_request(:post, 'http://hackney.api:8000/v1/repairs')
+      expect(a_request(:post, 'http://hackney.api:8000/hackneyrepairs/repairs')
         .with(
           body: request_json,
           headers: { content_type: 'application/json' }
@@ -312,20 +312,20 @@ RSpec.describe JsonApi do
     it 'parses a JSON response' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       response_params = { repair_request_id: '00045678' }
-      stub_request(:post, 'http://hackney.api:8000/v1/repairs')
+      stub_request(:post, 'http://hackney.api:8000/hackneyrepairs/repairs')
         .to_return(body: response_params.to_json)
 
-      result = json_api.post('v1/repairs', {})
+      result = json_api.post('hackneyrepairs/repairs', {})
       expect(result).to eq('repair_request_id' => '00045678')
     end
 
     context 'when the response was not valid JSON' do
       it 'raises an exception' do
         json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:post, 'http://hackney.api:8000/v1/repairs')
+        stub_request(:post, 'http://hackney.api:8000/hackneyrepairs/repairs')
           .to_return(body: 'not found')
 
-        expect { json_api.post('/v1/repairs', {}) }
+        expect { json_api.post('/hackneyrepairs/repairs', {}) }
           .to raise_error(JsonApi::InvalidResponseError, "765: unexpected token at 'not found'")
       end
     end


### PR DESCRIPTION
As part of some reorganisation of HackneyAPI, the root path is based at `hackneyrepairs` instead of `v1`.

I have been unable to do any tests on this locally, as I don't have access to the network the API server is restricted to yet.