### PR TITLE
Change Hackney API URLs

### DIFF
--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -78,7 +78,7 @@ class JsonApi
   class ConnectionBuilder
     def build(
       logger,
-      api_root: ENV['HACKNEY_API_ROOT'],
+      api_root: ENV['HACKNEY_API_ROOT'] + 'hackneyrepairs/',
       api_cert: ENV['PROXY_API_CERT'],
       api_key: ENV['PROXY_API_KEY']
     )


### PR DESCRIPTION
As part of some reorganisation of HackneyAPI, the root path of the API is now prefixed with /hackneyrepairs/

I have been unable to do any tests on this locally, as I don't have access to the network the API server is restricted to yet.