### PR TITLE
Report another repair

### DIFF
--- a/app/assets/stylesheets/hackney.scss
+++ b/app/assets/stylesheets/hackney.scss
@@ -50,3 +50,11 @@ body {
 .wrapper {
   @extend %site-width-container;
 }
+
+input.link {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  display: inline;
+}

--- a/app/controllers/address_searches_controller.rb
+++ b/app/controllers/address_searches_controller.rb
@@ -1,6 +1,13 @@
 class AddressSearchesController < ApplicationController
   def index
-    @address_search = AddressSearch.new
+    if selected_answer_store.address?
+      @address = selected_answer_store.selected_answers['address']
+      repair_params = RepairParams.new(selected_answer_store.selected_answers)
+      @diagnosed = repair_params.diagnosed?
+      render template: 'address_searches/confirm_address'
+    else
+      @address_search = AddressSearch.new
+    end
   end
 
   def create
@@ -11,6 +18,11 @@ class AddressSearchesController < ApplicationController
     else
       render :index
     end
+  end
+
+  def destroy
+    selected_answer_store.clear_address!
+    redirect_to action: :index
   end
 
   private

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -1,6 +1,15 @@
 class ContactDetailsController < ApplicationController
   def index
-    @form = ContactDetailsForm.new
+    contact_details = selected_answer_store.selected_answers['contact_details']
+    if contact_details
+      default_values = {
+        full_name: contact_details['full_name'],
+        telephone_number: contact_details['telephone_number'],
+      }
+    else
+      default_values = {}
+    end
+    @form = ContactDetailsForm.new(default_values)
   end
 
   def submit

--- a/app/controllers/contact_details_with_callback_controller.rb
+++ b/app/controllers/contact_details_with_callback_controller.rb
@@ -1,8 +1,16 @@
 class ContactDetailsWithCallbackController < ApplicationController
   def index
     @selected_answers = selected_answer_store.selected_answers['address']
-
-    @form = ContactDetailsWithCallbackForm.new
+    contact_details = selected_answer_store.selected_answers['contact_details']
+    if contact_details
+      default_values = {
+        full_name: contact_details['full_name'],
+        telephone_number: contact_details['telephone_number'],
+      }
+    else
+      default_values = {}
+    end
+    @form = ContactDetailsWithCallbackForm.new(default_values)
   end
 
   def submit

--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -1,7 +1,11 @@
 module Questions
   class StartController < ApplicationController
     def index
-      reset_session
+      if params[:keep_address]
+        selected_answer_store.reset_repair_questions!
+      else
+        reset_session
+      end
 
       @form = StartForm.new
     end

--- a/app/models/selected_answer_store.rb
+++ b/app/models/selected_answer_store.rb
@@ -10,4 +10,19 @@ class SelectedAnswerStore
   def selected_answers
     @session[:selected_answers] ||= {}
   end
+
+  def reset_repair_questions!
+    @session[:selected_answers] = @session[:selected_answers].select do |key|
+      %w[address contact_details].include? key
+    end
+  end
+
+  def clear_address!
+    selected_answers.delete('address')
+  end
+
+  def address?
+    selected_address = selected_answers['address']
+    selected_address.present? && selected_address.present?
+  end
 end

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -4,7 +4,9 @@ class HackneyApi
   end
 
   def list_properties(postcode:)
-    response = @json_api.get('hackneyrepairs/v1/properties?postcode=' + postcode)
+    response = @json_api.get(
+      'hackneyrepairs/v1/properties?postcode=' + postcode
+    )
     response.fetch('results')
   end
 
@@ -22,7 +24,9 @@ class HackneyApi
 
   def list_available_appointments(work_order_reference:)
     response = @json_api.get(
-      'hackneyrepairs/v1/work_orders/' + work_order_reference + '/available_appointments'
+      'hackneyrepairs/v1/work_orders/' +
+      work_order_reference +
+      '/available_appointments'
     )
     response.fetch('results')
   end

--- a/app/views/address_searches/confirm_address.html.haml
+++ b/app/views/address_searches/confirm_address.html.haml
@@ -1,0 +1,18 @@
+= back_link
+%h1
+  Confirm address
+
+%p
+  Is this the address for repair?
+
+%p
+  %aside#progress
+    = @address['address']
+    = @address['postcode']
+    = button_to "Change", destroy_address_search_path, method: :delete, class: 'link'
+
+%p
+  - if @diagnosed
+    = link_to "Confirm", contact_details_path, class: 'button'
+  - else
+    = link_to "Confirm", contact_details_with_callback_path, class: 'button'

--- a/app/views/confirmations/show.html.haml
+++ b/app/views/confirmations/show.html.haml
@@ -14,6 +14,7 @@
 
     = render @confirmation.scheduled_action
 
+  = link_to "Report another repair", questions_start_path(keep_address: true)
 .grid-row
   %section#summary.column-two-thirds
     %h3 Your details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   get '/address-search', to: 'address_searches#index', as: 'address_search'
   post '/address-search', to: 'address_searches#create'
+  delete '/address-search', to: 'address_searches#destroy', as: 'destroy_address_search'
 
   resource :address, only: [:create]
   resources :confirmations, only: [:show]

--- a/spec/features/resident_can_submit_another_repair_spec.rb
+++ b/spec/features/resident_can_submit_another_repair_spec.rb
@@ -1,0 +1,285 @@
+require 'rails_helper'
+RSpec.feature 'Resident can see a confirmation of their repair request' do
+  around(:each) do |example|
+    travel_to Time.zone.local(2017, 10, 1) do
+      example.run
+    end
+  end
+  scenario 'when the issue could not be completely diagnosed (and a callback is required)' do
+    property = {
+      'propertyReference' => '00000503',
+      'address' => 'Ross Court 23',
+      'postcode' => 'E5 8TE',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:post)
+      .with('hackneyrepairs/v1/repairs', anything)
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other",
+        'propertyReference' => '00000503',
+      )
+    allow(fake_api).to receive(:get)
+      .with('hackneyrepairs/v1/repairs/00367923')
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other",
+        'propertyReference' => '00000503',
+      )
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    fake_question_set = stub_diagnosis_question(question: 'Which room?', answers: [
+                                                  { 'text' => 'Kitchen', 'next' => 'kitchen' },
+                                                  { 'text' => 'Bathroom', 'desc' => 'describe_problem' },
+                                                  { 'text' => 'Other', 'desc' => 'describe_problem' },
+                                                ])
+
+    # FIRST REPAIR (no code)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Other'
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E5 8TE'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Ross Court 23'
+    click_on 'Continue'
+
+    # Contact details - last page before confirmation:
+    fill_in 'Full name', with: 'John Evans'
+    fill_in 'Telephone number', with: '078 98765 432'
+    check 'morning (8am to midday)'
+    check 'afternoon (midday to 5pm)'
+    click_on 'Continue'
+    aggregate_failures do
+      within '#confirmation' do
+        expect(page).to have_content 'Your reference number is 00367923'
+        expect(page).to have_content 'between 8am and 5pm'
+      end
+
+      within '#summary' do
+        expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
+        expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
+        expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
+      end
+    end
+
+    expect(fake_api).to have_received(:post).with(
+      'hackneyrepairs/v1/repairs',
+      priority: 'N',
+      problemDescription: "Callback requested: between 8am and 5pm\n\nMy sink is blocked",
+      propertyReference: '00000503',
+      contact: {
+        name: 'John Evans',
+        telephoneNumber: '078 98765 432',
+      },
+    )
+
+    # SECOND REPAIR (no code)
+
+    click_on 'Report another repair'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Bathroom'
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'My sink is leaking'
+    click_on 'Continue'
+
+    # Address
+    expect(page).to have_content 'Ross Court 23'
+    expect(page).to have_content 'E5 8TE'
+
+    click_on 'Confirm'
+
+    expect(page).to have_selector("input[value='John Evans']")
+    expect(page).to have_selector("input[value='078 98765 432']")
+    check 'morning (8am to midday)'
+    check 'afternoon (midday to 5pm)'
+    click_on 'Continue'
+
+    aggregate_failures do
+      within '#confirmation' do
+        expect(page).to have_content 'Your reference number is 00367923'
+        expect(page).to have_content 'between 8am and 5pm'
+      end
+
+      within '#summary' do
+        expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
+        expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
+        expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
+      end
+    end
+
+    expect(fake_api).to have_received(:post).with(
+      'hackneyrepairs/v1/repairs',
+      priority: 'N',
+      problemDescription: "Room: Bathroom\nCallback requested: between 8am and 5pm\n\nMy sink is leaking",
+      propertyReference: '00000503',
+      contact: {
+        name: 'John Evans',
+        telephoneNumber: '078 98765 432',
+      },
+    )
+
+    # THIRD REPAIR (code), edit address
+
+    click_on 'Report another repair'
+
+    ClimateControl.modify(ENCRYPTION_SECRET: 'test') do
+      property = {
+        'propertyReference' => '00000504',
+        'address' => 'Ross Court 22',
+        'postcode' => 'E5 8TE',
+      }
+      allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+      allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000504').and_return(property)
+      allow(fake_api).to receive(:post)
+        .with('hackneyrepairs/v1/repairs', anything)
+        .and_return(
+          'repairRequestReference' => '00367923',
+          'priority' => 'N',
+          'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+          'propertyReference' => '00000504',
+          'workOrders' => [
+            {
+              'sorCode' => '0078965',
+              'workOrderReference' => '09124578',
+            },
+          ]
+        )
+      allow(fake_api).to receive(:get)
+        .with('hackneyrepairs/v1/repairs/00367923')
+        .and_return(
+          'repairRequestReference' => '00367923',
+          'priority' => 'N',
+          'problem' => "My sink is blocked\n\nRoom: Kitchen\n\nLast question: \"Is your tap broken?\" -> Yes",
+          'propertyReference' => '00000504',
+          'workOrders' => [
+            {
+              'sorCode' => '0078965',
+              'workOrderReference' => '09124578',
+            },
+          ]
+        )
+      allow(fake_api).to receive(:get)
+        .with('hackneyrepairs/v1/work_orders/09124578/available_appointments')
+        .and_return(
+          'results' => [
+            { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true },
+            { 'beginDate' => '2017-10-11T12:00:00Z', 'endDate' => '2017-10-11T17:00:00Z', 'bestSlot' => true },
+          ]
+        )
+      allow(fake_api).to receive(:post)
+        .with(
+          'hackneyrepairs/v1/work_orders/09124578/appointments',
+          beginDate: '2017-10-11T12:00:00Z',
+          endDate: '2017-10-11T17:00:00Z',
+        )
+        .and_return(
+          'beginDate' => '2017-10-11T12:00:00Z',
+          'endDate' => '2017-10-11T17:00:00Z',
+          'status' => 'booked',
+        )
+
+      stub_diagnosis_question(double: fake_question_set, question: 'Is your tap broken?', id: 'kitchen', answers: [
+                                { 'text' => 'Yes', 'sor_code' => '0078965', 'desc' => 'kitchen_problem' },
+                                { 'text' => 'No' },
+                              ])
+
+      # Emergency page:
+      choose_radio_button 'No'
+      click_on 'Continue'
+
+      # Fake decision tree
+      choose_radio_button 'Kitchen'
+      click_on 'Continue'
+
+      choose_radio_button 'Yes'
+      click_on 'Continue'
+
+      # Describe problem:
+      fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+      click_on 'Continue'
+
+      # Contact details:
+      expect(page).to have_content 'Ross Court 23'
+      expect(page).to have_content 'E5 8TE'
+
+      click_on 'Change'
+
+      # Address search:
+      fill_in 'Postcode', with: 'E5 8TE'
+      click_on 'Find my address'
+
+      # Address selection:
+      choose_radio_button 'Ross Court 22'
+      click_on 'Continue'
+
+      expect(page).to have_selector("input[value='John Evans']")
+      expect(page).to have_selector("input[value='078 98765 432']")
+      click_on 'Continue'
+
+      # Appointments:
+      choose_radio_button 'Wednesday midday to 5pm (11th October)'
+      click_on 'Continue'
+
+      aggregate_failures do
+        within '#confirmation' do
+          expect(page).to have_content 'Your reference number is 09124578'
+          expect(page).to have_content 'Wednesday 11th October'
+          expect(page).to have_content 'between midday and 5pm'
+        end
+
+        within '#summary' do
+          expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
+          expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
+          expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 22, E5 8TE')
+        end
+      end
+
+      expect(fake_api).to have_received(:post).with(
+        'hackneyrepairs/v1/repairs',
+        priority: 'N',
+        problemDescription: "Room: Kitchen\n\nMy sink is blocked",
+        propertyReference: '00000504',
+        contact: {
+          name: 'John Evans',
+          telephoneNumber: '078 98765 432',
+        },
+        workOrders: [
+          { sorCode: '0078965' },
+        ]
+      )
+
+      expect(fake_api).to have_received(:post).with(
+        'hackneyrepairs/v1/work_orders/09124578/appointments',
+        beginDate: '2017-10-11T12:00:00Z',
+        endDate: '2017-10-11T17:00:00Z',
+      )
+    end
+  end
+end

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -44,8 +44,9 @@ RSpec.feature 'Resident can navigate back', js: true do
     expect(page).to have_content 'What is your address?'
     click_on t('back_link')
 
-    # Address search:
-    expect(page).to have_content 'What is your address?'
+    # Address confirmation:
+    expect(page).to have_content 'Confirm address'
+    expect(page).to have_content 'Flat 1, 8 Hoxton Square'
     click_on t('back_link')
 
     expect(page).to have_content 'Let us know any further details'
@@ -100,8 +101,9 @@ RSpec.feature 'Resident can navigate back', js: true do
     expect(page).to have_content 'What is your address?'
     click_on t('back_link')
 
-    # Address search:
-    expect(page).to have_content 'What is your address?'
+    # Address confirmation:
+    expect(page).to have_content 'Confirm address'
+    expect(page).to have_content 'Flat 1, 8 Hoxton Square'
     click_on t('back_link')
 
     expect(page).to have_content 'Let us know any further details you think might help us'

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -3,12 +3,13 @@ module CapybaraHelpers
     find(:label, text: label).click
   end
 
-  def stub_diagnosis_question(answers:, question: 'Dummy question', id: 'which_room')
-    fake_question_set = instance_double(QuestionSet)
+  def stub_diagnosis_question(answers:, question: 'Dummy question', id: 'which_room', double: nil)
+    fake_question_set = double || instance_double(QuestionSet)
     allow(fake_question_set)
       .to receive(:find)
       .with(id)
       .and_return(Question.new('id' => id, 'question' => question, 'answers' => answers))
     allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+    fake_question_set
   end
 end


### PR DESCRIPTION
Add new link at end of process to restart process, but retain address and contact
details.
If address is present, then new address confirmation page
New method for removing address information if user wants to change
If contact details present, then prefill form with them

Resolves trello card [40-add-another-repair-feature](https://trello.com/c/jSWJPrFR)

New "Add another repair" link on confirmation page:
![1b17740d-4e12-4241-8375-666c11414813](https://user-images.githubusercontent.com/425/40362127-8df32616-5dc3-11e8-874b-14b96d7439c6.png)

New address confirmation page:
![13e31cc1-6594-4e58-8577-c139a85b5028](https://user-images.githubusercontent.com/425/40362150-9fcd0f32-5dc3-11e8-960b-1cec20840557.png)
