### PR TITLE
(fix) Improve wording in start page

### DIFF
--- a/app/views/pages/start.html.haml
+++ b/app/views/pages/start.html.haml
@@ -2,8 +2,7 @@
   Report a repair
 
 %p.lede
-  We provide housing and communal area repairs for council tenants,
-  and communal repairs for leaseholders.
+  We provide housing repairs for council tenants through this online service.
 
 %p
   You can use this service to:
@@ -15,7 +14,7 @@
     choose a date and time for us to carry out the repair
 
 %p
-  Reporting a repair should take less than 5 minutes.
+  Reporting a single repair should take less than 5 minutes.
 
 %p.notice
   %i.icon.icon-important
@@ -42,6 +41,17 @@
   We're open
   = succeed '.' do
     = t('rcc_opening_hours')
+
+%h2
+  Communal repairs
+
+%p
+  If you need to report a repair within a communal area
+  such as lift, entry doors and lighting,
+  %br/
+  please call us on
+  = succeed '.' do
+    = repairs_contact_centre_telephone_number
 
 %h2
   Home improvements

--- a/spec/features/users_are_sent_to_one_account_when_bouncing_enabled_spec.rb
+++ b/spec/features/users_are_sent_to_one_account_when_bouncing_enabled_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Users visiting our landing page from hackney.gov.uk' do
     visit '/landing'
 
     expect(page.current_path).to eql '/'
-    expect(page).to have_content 'We provide housing and communal area repairs for council tenants'
+    expect(page).to have_content 'We provide housing repairs for council tenants through this online service'
   end
 
   scenario 'redirected to One Account, when bouncing is enabled' do


### PR DESCRIPTION
Trello Card [50-emergency-journey-change-content-on-the-start-page](https://trello.com/c/4czR4rkK/)

Improves content on the start page to better indicate that the service is for raising housing repairs and not communal.

![start page](https://user-images.githubusercontent.com/2632224/40437723-09a3192a-5eae-11e8-9d11-b74cd85bb920.png)
