### PR TITLE
(fix) Improved wording in room choice page

### DIFF
--- a/db/questions.yml
+++ b/db/questions.yml
@@ -1,6 +1,6 @@
 ---
 which_room:
-  question: In which room is the problem located?
+  question: Where is the problem located?
   answers:
     - text: Kitchen
       next: kitchen_problem
@@ -8,7 +8,7 @@ which_room:
     - text: Bathroom
       next: bathroom_problem
 
-    - text: Other
+    - text: Elsewhere in my property
       next: other_problem
 
 kitchen_problem:

--- a/spec/features/users_can_answer_repair_questions_spec.rb
+++ b/spec/features/users_can_answer_repair_questions_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Users can answer repair questions' do
     click_continue
 
     within '.question' do
-      expect(page).to have_content 'In which room is the problem located?'
+      expect(page).to have_content 'Where is the problem located?'
     end
   end
 


### PR DESCRIPTION
Trello card [51-emergency-journey-change-main-question-and-other-on-the-room-choice-page](https://trello.com/c/L3IER9re/)

We have learned from testing with users that 'Other' on the 'Room choice' page is vague and confusing and it tends to be used to try to raise a communal repair.

This is now changed to 'Elsewhere in my property' to make it more clear that it indicates a different place in the flat.

![screen shot 2018-05-24 at 14 46 14](https://user-images.githubusercontent.com/2632224/40489533-3eabbcfe-5f61-11e8-848c-82b7770ec747.png)
