### PR TITLE
(feature)Create specific page for no water emergency

### DIFF
--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -15,21 +15,7 @@ module Questions
 
       return render :index if @form.invalid?
 
-      next_page = case @form.answer
-                  when 'smell_gas'
-                    page_path('gas')
-                  when 'no_heating'
-                    page_path('heating_repairs')
-                  when 'no_water'
-                    page_path('no_water')
-                  when 'home_adaptations'
-                    page_path('home_adaptations')
-                  when 'none_of_the_above'
-                    questions_path('which_room')
-                  else
-                    page_path('emergency_contact')
-                  end
-
+      next_page = page_mapping[@form.answer] || page_path('emergency_contact')
       redirect_to next_page
     end
 
@@ -37,6 +23,16 @@ module Questions
 
     def start_form_params
       params.require(:start_form).permit(:answer)
+    end
+
+    def page_mapping
+      {
+        'smell_gas' => page_path('gas'),
+        'no_heating' => page_path('heating_repairs'),
+        'no_water' => page_path('no_water'),
+        'home_adaptations' => page_path('home_adaptations'),
+        'none_of_the_above' => questions_path('which_room'),
+      }
     end
   end
 end

--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -20,6 +20,8 @@ module Questions
                     page_path('gas')
                   when 'no_heating'
                     page_path('heating_repairs')
+                  when 'no_water'
+                    page_path('no_water')
                   when 'home_adaptations'
                     page_path('home_adaptations')
                   when 'none_of_the_above'

--- a/app/views/pages/no_water.html.haml
+++ b/app/views/pages/no_water.html.haml
@@ -1,0 +1,26 @@
+= back_link
+
+%h1
+  What to do if you have no water
+
+%br/
+
+%h2
+  If you don't have drinking water in the kitchen
+
+%p
+  Please call Thames Water on
+  %strong
+    = succeed '.' do
+      = water_emergency_telephone_number
+
+%h2
+  If you don't have water in the bathroom or toilet
+
+%p
+  Please call our Repairs Contact Centre on
+  %strong
+    = succeed ',' do
+      = repairs_contact_centre_telephone_number
+  this will allow us to review your repair straight away
+  and schedule an appointment.

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Questions::StartController do
         expect(response).to redirect_to '/pages/heating_repairs'
       end
 
+      it 'shows the no water repairs page' do
+        post :submit, params: { start_form: { answer: 'no_water' } }
+
+        expect(response).to redirect_to '/pages/no_water'
+      end
+
       it 'shows the home adaptations page' do
         post :submit, params: { start_form: { answer: 'home_adaptations' } }
 


### PR DESCRIPTION
Trello [53-emergency-journey-i-have-no-water-create-new-page](https://trello.com/c/AiV5CoDk/)

If a user chooses 'I have no water' option from emergency triage page they can get an answer specifically related to their repair problem.

Created a new page that explains to the user what to do if they have no water.

![screen shot 2018-05-24 at 17 35 50](https://user-images.githubusercontent.com/2632224/40499185-1641f3b0-5f79-11e8-9acb-9d0774fad49d.png)


