### PR TITLE
(feature) screening filter page

### DIFF
--- a/app/controllers/questions/screening_filter_controller.rb
+++ b/app/controllers/questions/screening_filter_controller.rb
@@ -1,0 +1,32 @@
+module Questions
+  class ScreeningFilterController < ApplicationController
+    def index
+      @form = ScreeningFilterForm.new
+    end
+
+    def submit
+      @form = ScreeningFilterForm.new(form_params)
+
+      return render :index if @form.invalid?
+
+      next_page = page_mapping[@form.answer] || page_path('emergency_contact')
+      redirect_to next_page
+    end
+
+    private
+
+    def form_params
+      params.require(:screening_filter_form).permit(:answer)
+    end
+
+    def page_mapping
+      {
+        'communal' => page_path('communal'),
+        'home_adaptations' => page_path('home_adaptations'),
+        'multiple_properties' => page_path('multiple_properties'),
+        'recent_repair' => page_path('recent_repair'),
+        'none_of_the_above' => questions_path('which_room'),
+      }
+    end
+  end
+end

--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -30,8 +30,7 @@ module Questions
         'smell_gas' => page_path('gas'),
         'no_heating' => page_path('heating_repairs'),
         'no_water' => page_path('no_water'),
-        'home_adaptations' => page_path('home_adaptations'),
-        'none_of_the_above' => questions_path('which_room'),
+        'none_of_the_above' => questions_path('screening_filter'),
       }
     end
   end

--- a/app/models/screening_filter_form.rb
+++ b/app/models/screening_filter_form.rb
@@ -1,4 +1,4 @@
-class StartForm
+class ScreeningFilterForm
   include ActiveModel::Model
 
   attr_reader :answer
@@ -12,12 +12,10 @@ class StartForm
 
   def choices
     %i[
-      smell_gas
-      no_heating
-      no_water
-      no_power
-      water_leak
-      not_secure_access
+      communal
+      home_adaptations
+      multiple_properties
+      recent_repair
       none_of_the_above
     ]
   end

--- a/app/views/pages/communal.html.haml
+++ b/app/views/pages/communal.html.haml
@@ -1,0 +1,15 @@
+= back_link
+
+%h1
+  Communal repair
+
+%p
+  If a repair is needed in a communal area,
+  please call us so we can review your
+  repair and schedule an appointment.
+
+%p
+  Repairs Contact Centre:
+  %strong= repairs_contact_centre_telephone_number
+  = succeed '.' do
+    = t('rcc_opening_hours')

--- a/app/views/pages/multiple_properties.html.haml
+++ b/app/views/pages/multiple_properties.html.haml
@@ -1,0 +1,15 @@
+= back_link
+
+%h1
+  Multiple Properties
+
+%p
+  If your issue is affecting multiple properties,
+  please call us so we can review your
+  repair and schedule an appointment.
+
+%p
+  Repairs Contact Centre:
+  %strong= repairs_contact_centre_telephone_number
+  = succeed '.' do
+    = t('rcc_opening_hours')

--- a/app/views/pages/recent_repair.html.haml
+++ b/app/views/pages/recent_repair.html.haml
@@ -1,0 +1,15 @@
+= back_link
+
+%h1
+  Recent Repair
+
+%p
+  If your issue is about a recent repair,
+  please call us so we can review your
+  repair and schedule an appointment.
+
+%p
+  Repairs Contact Centre:
+  %strong= repairs_contact_centre_telephone_number
+  = succeed '.' do
+    = t('rcc_opening_hours')

--- a/app/views/questions/screening_filter/index.html.haml
+++ b/app/views/questions/screening_filter/index.html.haml
@@ -1,0 +1,12 @@
+= simple_form_for @form, url: request.fullpath do |f|
+  %fieldset
+    %legend.question
+      %h1 Before you continue
+
+      %p
+        %strong
+          Do any of the following apply?
+
+    .answers
+      = f.input :answer, collection: @form.choices, as: :radio_buttons, label: false
+      = f.button :submit, class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,12 @@ en:
           no_power: I have no power
           water_leak: I have a water leak which I can't contain
           not_secure_access: I can't secure my property
+          none_of_the_above: No, my problem is not one of the above
+      screening_filter_form:
+        answer:
+          communal: Repair is in the communal area
           home_adaptations: My home has been adapted for my disability
+          multiple_properties: Repair problem affects multiple properties
+          recent_repair: Repair was made within the last month
           none_of_the_above: No, my problem is not one of the above
   title: Report a repair

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   namespace :questions do
     get '/start', to: 'start#index', as: 'start'
     post '/start', to: 'start#submit'
+    get '/screening_filter', to: 'screening_filter#index', as: 'screening_filter'
+    post '/screening_filter', to: 'screening_filter#submit'
   end
 
   get '/questions/:id', to: 'questions#show', as: 'questions'

--- a/spec/controllers/screening_filter_controller_spec.rb
+++ b/spec/controllers/screening_filter_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Questions::ScreeningFilterController do
+  describe '#submit' do
+    context 'shows different content based on user choice' do
+      it 'shows the communal page' do
+        post :submit, params: { screening_filter_form: { answer: 'communal' } }
+
+        expect(response).to redirect_to '/pages/communal'
+      end
+
+      it 'shows the home adaptations page' do
+        post :submit, params: { screening_filter_form: { answer: 'home_adaptations' } }
+
+        expect(response).to redirect_to '/pages/home_adaptations'
+      end
+
+      it 'shows the multiple properties page' do
+        post :submit, params: { screening_filter_form: { answer: 'multiple_properties' } }
+
+        expect(response).to redirect_to '/pages/multiple_properties'
+      end
+
+      it 'shows the recent repair page' do
+        post :submit, params: { screening_filter_form: { answer: 'recent_repair' } }
+
+        expect(response).to redirect_to '/pages/recent_repair'
+      end
+
+      it 'shows the which_room question' do
+        post :submit, params: { screening_filter_form: { answer: 'none_of_the_above' } }
+
+        expect(response).to redirect_to '/questions/which_room'
+      end
+
+      it 'shows the standard emergency contact page for other values' do
+        post :submit, params: { screening_filter_form: { answer: 'xxxx' } }
+
+        expect(response).to redirect_to '/pages/emergency_contact'
+      end
+    end
+  end
+end

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -21,16 +21,10 @@ RSpec.describe Questions::StartController do
         expect(response).to redirect_to '/pages/no_water'
       end
 
-      it 'shows the home adaptations page' do
-        post :submit, params: { start_form: { answer: 'home_adaptations' } }
-
-        expect(response).to redirect_to '/pages/home_adaptations'
-      end
-
-      it 'shows the which_room question' do
+      it 'shows the screening filter question' do
         post :submit, params: { start_form: { answer: 'none_of_the_above' } }
 
-        expect(response).to redirect_to '/questions/which_room'
+        expect(response).to redirect_to '/questions/screening_filter'
       end
 
       it 'shows the standard emergency contact page for other values' do

--- a/spec/features/resident_can_submit_another_repair_spec.rb
+++ b/spec/features/resident_can_submit_another_repair_spec.rb
@@ -47,6 +47,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'Other'
     click_on 'Continue'
@@ -98,6 +102,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     click_on 'Report another repair'
 
     # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Filter page:
     choose_radio_button 'No'
     click_on 'Continue'
 
@@ -211,6 +219,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
                               ])
 
       # Emergency page:
+      choose_radio_button 'No'
+      click_on 'Continue'
+
+      # Filter page:
       choose_radio_button 'No'
       click_on 'Continue'
 

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -21,6 +21,10 @@ RSpec.feature 'Resident can navigate back', js: true do
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'diagnose'
     click_continue
@@ -78,6 +82,10 @@ RSpec.feature 'Resident can navigate back', js: true do
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'skip'
     click_continue
@@ -125,6 +133,10 @@ RSpec.feature 'Resident can navigate back', js: true do
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'skip'
     click_continue
@@ -164,6 +176,10 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Start'
 
     # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Filter page:
     choose_radio_button 'No'
     click_on 'Continue'
 
@@ -212,6 +228,10 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Start'
 
     # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Filter page:
     choose_radio_button 'No'
     click_on 'Continue'
 
@@ -274,6 +294,10 @@ RSpec.feature 'Resident can navigate back', js: true do
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'skip'
     click_continue
@@ -305,6 +329,10 @@ RSpec.feature 'Resident can navigate back', js: true do
     click_on 'Start'
 
     # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Filter page:
     choose_radio_button 'No'
     click_on 'Continue'
 

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -103,6 +103,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       choose_radio_button 'No'
       click_on 'Continue'
 
+      # Filter page:
+      choose_radio_button 'No'
+      click_on 'Continue'
+
       # Fake decision tree
       choose_radio_button 'Kitchen'
       click_on 'Continue'
@@ -215,6 +219,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     click_on 'Start'
 
     # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Filter page:
     choose_radio_button 'No'
     click_on 'Continue'
 

--- a/spec/features/residents_see_nice_errors_spec.rb
+++ b/spec/features/residents_see_nice_errors_spec.rb
@@ -68,6 +68,10 @@ RSpec.feature 'Error pages' do
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'Kitchen'
     click_on 'Continue'
@@ -87,4 +91,3 @@ RSpec.feature 'Error pages' do
       .with(connection_error)
   end
 end
-

--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -82,6 +82,10 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'Kitchen'
     click_on 'Continue'

--- a/spec/features/users_can_answer_repair_questions_spec.rb
+++ b/spec/features/users_can_answer_repair_questions_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'Users can answer repair questions' do
       expect(page).to have_content t('simple_form.options.start_form.answer.no_water')
       expect(page).to have_content t('simple_form.options.start_form.answer.no_power')
       expect(page).to have_content t('simple_form.options.start_form.answer.water_leak')
-      expect(page).to have_content t('simple_form.options.start_form.answer.home_adaptations')
       expect(page).to have_content t('simple_form.options.start_form.answer.none_of_the_above')
     end
 
@@ -45,7 +44,7 @@ RSpec.feature 'Users can answer repair questions' do
     click_continue
 
     within '.question' do
-      expect(page).to have_content 'Where is the problem located?'
+      expect(page).to have_content 'Do any of the following apply?'
     end
   end
 

--- a/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
+++ b/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
@@ -98,6 +98,10 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
     choose_radio_button 'No'
     click_on 'Continue'
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'Kitchen'
     click_on 'Continue'
@@ -110,6 +114,10 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
     click_on 'Start'
 
     # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Filter page:
     choose_radio_button 'No'
     click_on 'Continue'
 

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -24,6 +24,10 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     choose_radio_button 'No'
     click_continue
 
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
     # Fake decision tree
     choose_radio_button 'skip'
     click_continue
@@ -81,6 +85,10 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     # Emergency repairs
     choose_radio_button 'No'
     click_continue
+
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
 
     # Fake decision tree
     choose_radio_button 'diagnose'


### PR DESCRIPTION
We have a new page for filtering out some common reasons that a user cannot use this system.
Adds this page after the emergency filter.
Adds new pages for communal, multiple property and recent repairs.
Moves home adaptations to this new page instead of emergency page.
<img width="572" alt="screenshot 2018-05-29 12 38 06" src="https://user-images.githubusercontent.com/425/40656699-28834e8a-633d-11e8-897b-136b811b1c35.png">

I have freestyled on the copy for the communal, multiple property and recent repairs pages.