### PR TITLE
Add repair as button and notice on description page

### DIFF
--- a/app/assets/stylesheets/components/main.scss
+++ b/app/assets/stylesheets/components/main.scss
@@ -95,4 +95,14 @@ main {
       font-weight: bold;
     }
   }
+
+  .info-notice {
+    border-left: 1em solid #dee0e2;
+    padding: 1em 0 1em 1em;
+    margin: 0 0 2em 0;
+
+    p:last-child, ul:last-child, ol:last-child {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/app/views/confirmations/_appointment.html.haml
+++ b/app/views/confirmations/_appointment.html.haml
@@ -7,6 +7,8 @@
     = succeed '.' do
       = appointment.time
 
+= link_to "Report another repair", questions_start_path(keep_address: true), class: 'button'
+
 %p
   If you need to change your appointment or have any questions,
   please call us on

--- a/app/views/confirmations/_callback.html.haml
+++ b/app/views/confirmations/_callback.html.haml
@@ -3,6 +3,8 @@
   %strong= callback.time
   to arrange a repair appointment.
 
+= link_to "Report another repair", questions_start_path(keep_address: true), class: 'button'
+
 %p
   %strong
     If you have any questions, please call us on

--- a/app/views/confirmations/show.html.haml
+++ b/app/views/confirmations/show.html.haml
@@ -14,7 +14,6 @@
 
     = render @confirmation.scheduled_action
 
-  = link_to "Report another repair", questions_start_path(keep_address: true)
 .grid-row
   %section#summary.column-two-thirds
     %h3 Your details

--- a/app/views/describe_repair/index.html.haml
+++ b/app/views/describe_repair/index.html.haml
@@ -5,6 +5,10 @@
     %legend.question
       = render partial: @describe_repair.partial
 
+    .info-notice.column-two-thirds
+      %p
+        Please only report one repair at a time. You will have a chance to report another repair after this one.
+
     .answers
       = f.input :description, as: :text, input_html: { maxlength: 500 }
       = f.button :submit, class: 'button'


### PR DESCRIPTION
Resolves trello card
https://trello.com/c/CApWT7jI/64-improve-add-another-repair-design-on-relevant-pages

Made the 'add another repair' link more visible.
Added a notice to the user on repair description page, asking to report
one repair at a time.

For the users wanting to report multiple repairs this would give an
indication that it's possible and doesn't require writing multiple repairs
in the free text area on repair description page.

![localhost_3000_confirmations_03209407 laptop with hidpi screen](https://user-images.githubusercontent.com/2632224/40779143-c34b5040-64cb-11e8-909a-f2f9860f231a.png)
![localhost_3000_describe-repair_details inside_sockets laptop with hidpi screen](https://user-images.githubusercontent.com/2632224/40779144-c3628c06-64cb-11e8-9849-20a16ea856bd.png)
