### PR TITLE
New SOR for leaking pipe, removed SOR from condensation

### DIFF
--- a/app/views/pages/condensation_problem.html.haml
+++ b/app/views/pages/condensation_problem.html.haml
@@ -1,0 +1,24 @@
+= back_link
+
+%h1
+  What to do if you have a problem with condensation
+
+%p
+  Condensation is the moisture build up caused by
+  everyday activities such as cooking, showering/bathing
+  and drying clothes indoors. You can take some simple steps
+  to reduce condensation, helping to prevent damp and mould.
+
+%p
+  You can find helpul tips on how to prevent condensation
+  %a{ href: 'https://www.hackney.gov.uk/damp-and-mould#Preventing%20condensation' } on Hackney Council page.
+
+%p
+  If you need more guidance on how to deal with condensation you can call
+  Repairs Contact Centre.
+
+%p
+  Repairs Contact Centre:
+  %strong= repairs_contact_centre_telephone_number
+  = succeed '.' do
+    = t('rcc_opening_hours')

--- a/db/questions.yml
+++ b/db/questions.yml
@@ -511,14 +511,12 @@ drip_source:
   question: Is the source of the drip
   answers:
     - text: A pipe
-      sor_code: TODO - Plumber
+      sor_code: 20060060
       problem: Water leaking from a pipe
       desc: source_size_location_leak
 
     - text: Condensation
-      sor_code: PRE00001
-      problem: Damp caused by condensation
-      desc: size_location_condensation
+      page: condensation_problem
 
     - text: I'm not sure
       problem: Leak inside the property unknown source


### PR DESCRIPTION
Resolves Trello card [/79-damp-leak-mould-add-the-right-sor-codes](https://trello.com/c/ONXKUlKy)

Confirmed SOR codes for Damp and Moud.

A leaking pipe has a new SOR code, that also will need to be included in Hackney API.

Condensation does not book a surveyor, instead we give the user a helpful information on what causes condensation and give them a link to tips on how to prevent condensation available on Hackney Council website.

Condensation problem page:
![screen shot 2018-06-14 at 11 40 29](https://user-images.githubusercontent.com/2632224/41408196-c9c3950a-6fc9-11e8-873a-ce7f1d3bf05d.png)
