### PR TITLE
Filter appointments before 2 business days away

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'business_time'
 gem 'faker' # Use in all environments until we have a real API
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
     ast (2.3.0)
     bindex (0.5.0)
     builder (3.2.3)
+    business_time (0.9.3)
+      activesupport (>= 3.2.0)
+      tzinfo
     capybara (2.13.0)
       addressable
       mime-types (>= 1.16)
@@ -332,6 +335,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  business_time
   capybara
   climate_control
   dotenv-rails

--- a/app/services/appointment_fetcher.rb
+++ b/app/services/appointment_fetcher.rb
@@ -2,7 +2,7 @@ class AppointmentFetcher
   def call(work_order_reference:, limit:)
     @work_order_reference = work_order_reference
 
-    appointments = filter_before_tomorrow(available_appointments)
+    appointments = filter_to_soon(available_appointments)
     appointments = filter_long_slots(appointments)
 
     if best_slots?(appointments)
@@ -20,11 +20,11 @@ class AppointmentFetcher
     )
   end
 
-  def filter_before_tomorrow(appointments)
-    tomorrow = 1.day.from_now.at_beginning_of_day
+  def filter_to_soon(appointments)
+    earliest = 2.business_days.from_now
 
     appointments.select do |appointment|
-      Time.zone.parse(appointment.fetch('beginDate')) >= tomorrow
+      Time.zone.parse(appointment.fetch('beginDate')) >= earliest
     end
   end
 

--- a/spec/services/appointment_fetcher_spec.rb
+++ b/spec/services/appointment_fetcher_spec.rb
@@ -21,20 +21,25 @@ RSpec.describe AppointmentFetcher do
 
   it 'excludes appointment slots before tomorrow' do
     past_appointment = { 'beginDate' => '2017-10-09T16:00:00Z', 'endDate' => '2017-10-09T18:00:00Z', 'bestSlot' => true }
-    today_appointment = { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true }
-    tomorrow_appointment = { 'beginDate' => '2017-10-12T12:00:00Z', 'endDate' => '2017-10-12T17:00:00Z', 'bestSlot' => true }
+    today_appointment = { 'beginDate' => '2017-10-13T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true }
+    tomorrow_appointment = { 'beginDate' => '2017-10-14T12:00:00Z', 'endDate' => '2017-10-12T17:00:00Z', 'bestSlot' => true }
+    weekend_appointment = { 'beginDate' => '2017-10-15T12:00:00Z', 'endDate' => '2017-10-12T17:00:00Z', 'bestSlot' => true }
+    monday_appointment = { 'beginDate' => '2017-10-17T12:00:00Z', 'endDate' => '2017-10-12T17:00:00Z', 'bestSlot' => true }
 
-    stub_appointments([past_appointment, today_appointment, tomorrow_appointment])
+    stub_appointments([past_appointment, today_appointment, tomorrow_appointment, weekend_appointment, monday_appointment])
 
-    travel_to Time.zone.local(2017, 10, 11) do
+    # Today is Thursday
+    travel_to Time.zone.local(2017, 10, 13) do
       appointments = AppointmentFetcher.new.call(
         work_order_reference: '1234',
         limit: 15
       )
 
-      expect(appointments).to include tomorrow_appointment
+      expect(appointments).to include monday_appointment
+      expect(appointments).not_to include tomorrow_appointment
       expect(appointments).not_to include past_appointment
       expect(appointments).not_to include today_appointment
+      expect(appointments).not_to include weekend_appointment
     end
   end
 


### PR DESCRIPTION
Previously we filtered appointments that were on the same day as the booking: EG if you booked on a Thursday, you could book appointments as early as Friday morning.

This did not give planners enough time to plan accoringly. New rule is to give at least a whole business day before the appointment. EG Booking on Thursday will not allow appointments before Monday morning.