### PR TITLE
Fix footer social icons in Firefox

### DIFF
--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -58,8 +58,9 @@ footer {
 
   .social {
     li {
-      display: inline-block;
       text-indent: -9999px;
+      display: flex;
+      justify-content: center;
 
       a {
         background-color: #333;


### PR DESCRIPTION
Uses flexbox.

Tested in:

- Chrome on macOS
- Firefox on macOS
- Safari on macOS
- IE11 on Windows
- Edge on Windows

Resolves: https://dxw.zendesk.com/agent/tickets/9484