### PR TITLE
Support the new repair API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ root of the application containing environment variable assignments.
 
 The following environment variables are required to run the site:
 
-- `HACKNEY_API_ROOT` - the root of the Hackney API which is used by the site
+- `HACKNEY_API_URL` - the root of the Hackney API which is used by the site
 - `ENCRYPTION_SECRET` - secret used to prevent parameter tampering. Generate
   one with e.g. `rake secret`
 
@@ -44,8 +44,6 @@ The app should run successfully without these environment variables:
 - `HTTP_AUTH_USER` / `HTTP_AUTH_PASSWORD` - Set these to protect the site with
    [HTTP Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)
 - `FLIPPER_AUTH_USER` / `FLIPPER_AUTH_PASSWORD` - As above, but for feature flag UI
-- `PROXY_API_CERT` / `PROXY_API_KEY` - Client SSL certificate and associated
-  private key - used if connecting to the Hackney API via a proxy server
 
 #### Miscellaneous
 

--- a/app/models/repair.rb
+++ b/app/models/repair.rb
@@ -21,8 +21,7 @@ class Repair
 
   def supplier_reference
     return nil unless @repair_data.key?('workOrders')
-
-    @repair_data.fetch('workOrders')&.first&.fetch('supplierReference')
+    @repair_data.fetch('workOrders')&.first&.fetch('supplierRef')
   end
 
   def priority

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -5,26 +5,26 @@ class HackneyApi
 
   def list_properties(postcode:)
     response = @json_api.get(
-      'hackneyrepairs/v1/properties?postcode=' + postcode
+      'repairs/v1/properties?postcode=' + postcode
     )
     response.fetch('results')
   end
 
   def get_property(property_reference:)
-    @json_api.get('hackneyrepairs/v1/properties/' + property_reference)
+    @json_api.get('repairs/v1/properties/' + property_reference)
   end
 
   def create_repair(repair_params)
-    @json_api.post('hackneyrepairs/v1/repairs', repair_params)
+    @json_api.post('repairs/v1/repairs', repair_params)
   end
 
   def get_repair(repair_request_reference:)
-    @json_api.get('hackneyrepairs/v1/repairs/' + repair_request_reference)
+    @json_api.get('repairs/v1/repairs/' + repair_request_reference)
   end
 
   def list_available_appointments(work_order_reference:)
     response = @json_api.get(
-      'hackneyrepairs/v1/work_orders/' +
+      'repairs/v1/work_orders/' +
       work_order_reference +
       '/available_appointments'
     )
@@ -33,7 +33,7 @@ class HackneyApi
 
   def book_appointment(work_order_reference:, begin_date:, end_date:)
     @json_api.post(
-      'hackneyrepairs/v1/work_orders/' + work_order_reference + '/appointments',
+      'repairs/v1/work_orders/' + work_order_reference + '/appointments',
       beginDate: begin_date,
       endDate: end_date
     )

--- a/app/queries/json_api.rb
+++ b/app/queries/json_api.rb
@@ -78,39 +78,25 @@ class JsonApi
   class ConnectionBuilder
     def build(
       logger,
-      api_root: ENV['HACKNEY_API_ROOT'],
-      api_cert: ENV['PROXY_API_CERT'],
-      api_key: ENV['PROXY_API_KEY']
+      api_root: ENV['HACKNEY_API_URL']
     )
       raise InvalidApiRootError, 'API root was nil or empty' if api_root.blank?
 
       build_connection(
         root: api_root,
-        ssl: ssl_options(
-          cert: api_cert,
-          key: api_key,
-        ),
         logger: logger,
       )
     end
 
     private
 
-    def build_connection(root:, ssl:, logger:)
-      Faraday.new root, ssl: ssl do |conn|
+    def build_connection(root:, logger:)
+      Faraday.new root do |conn|
         conn.adapter Faraday.default_adapter
+        conn.headers["x-api-key"] = ENV['HACKNEY_API_TOKEN']
         conn.response :json
         conn.response :logger, logger, headers: true, bodies: true
       end
-    end
-
-    def ssl_options(cert:, key:)
-      return {} if cert.nil?
-      raise MissingPrivateKeyError if key.nil?
-      {
-        client_cert: OpenSSL::X509::Certificate.new(cert),
-        client_key:  OpenSSL::PKey::RSA.new(key),
-      }
     end
   end
 end

--- a/app/services/create_repair.rb
+++ b/app/services/create_repair.rb
@@ -26,6 +26,7 @@ class CreateRepair
     [
       {
         sorCode: params.sor_code,
+        estimatedunits: '1'
       },
     ]
   end

--- a/spec/features/leaseholders_cannot_report_in_dwelling_repairs_spec.rb
+++ b/spec/features/leaseholders_cannot_report_in_dwelling_repairs_spec.rb
@@ -11,10 +11,10 @@ RSpec.feature 'Leaseholders cannot report in-dwelling repairs' do
 
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/properties?postcode=N1 6NN')
+      .with('repairs/v1/properties?postcode=N1 6NN')
       .and_return('results' => [property])
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/properties/00001234')
+      .with('repairs/v1/properties/00001234')
       .and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 

--- a/spec/features/rcc_operative_can_see_spreadsheet_log_or_repairs.rb
+++ b/spec/features/rcc_operative_can_see_spreadsheet_log_or_repairs.rb
@@ -12,10 +12,10 @@ RSpec.feature 'RCC operative can see spreadsheet log of repairs' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('hackneyrepairs/v1/repairs', anything)
+      .with('repairs/v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -23,7 +23,7 @@ RSpec.feature 'RCC operative can see spreadsheet log of repairs' do
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/repairs/00367923')
+      .with('repairs/v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',

--- a/spec/features/resident_can_locate_problem_spec.rb
+++ b/spec/features/resident_can_locate_problem_spec.rb
@@ -22,8 +22,8 @@ RSpec.feature 'Resident can locate a problem' do
     matching_properties = [other_property, tenant_property]
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=N1 6NU').and_return('results' => matching_properties)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/abc123').and_return(tenant_property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=N1 6NU').and_return('results' => matching_properties)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/abc123').and_return(tenant_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -46,7 +46,7 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'when the address search returned no results' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=N1 6NU').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=N1 6NU').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -83,8 +83,8 @@ RSpec.feature 'Resident can locate a problem' do
 
   scenario 'changing the postcode after searching' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=N1 6AA').and_return('results' => [])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=N1 6NU').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=N1 6AA').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=N1 6NU').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -110,7 +110,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=N1 6NU').and_return('results' => [matching_property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=N1 6NU').and_return('results' => [matching_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'
@@ -132,7 +132,7 @@ RSpec.feature 'Resident can locate a problem' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=N1 6NU').and_return('results' => [other_property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=N1 6NU').and_return('results' => [other_property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     visit '/address-search'

--- a/spec/features/resident_can_submit_another_repair_spec.rb
+++ b/spec/features/resident_can_submit_another_repair_spec.rb
@@ -12,10 +12,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('hackneyrepairs/v1/repairs', anything)
+      .with('repairs/v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -23,7 +23,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/repairs/00367923')
+      .with('repairs/v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -89,7 +89,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'hackneyrepairs/v1/repairs',
+      'repairs/v1/repairs',
       priority: 'N',
       problemDescription: "Callback requested: between 8am and 5pm\n\nMy sink is blocked",
       propertyReference: '00000503',
@@ -145,7 +145,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'hackneyrepairs/v1/repairs',
+      'repairs/v1/repairs',
       priority: 'N',
       problemDescription: "Room: Bathroom\nCallback requested: between 8am and 5pm\n\nMy sink is leaking",
       propertyReference: '00000503',
@@ -165,10 +165,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'address' => 'Ross Court 22',
         'postcode' => 'E5 8TE',
       }
-      allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
-      allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000504').and_return(property)
+      allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+      allow(fake_api).to receive(:get).with('repairs/v1/properties/00000504').and_return(property)
       allow(fake_api).to receive(:post)
-        .with('hackneyrepairs/v1/repairs', anything)
+        .with('repairs/v1/repairs', anything)
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
@@ -182,7 +182,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           ]
         )
       allow(fake_api).to receive(:get)
-        .with('hackneyrepairs/v1/repairs/00367923')
+        .with('repairs/v1/repairs/00367923')
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
@@ -196,7 +196,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           ]
         )
       allow(fake_api).to receive(:get)
-        .with('hackneyrepairs/v1/work_orders/09124578/available_appointments')
+        .with('repairs/v1/work_orders/09124578/available_appointments')
         .and_return(
           'results' => [
             { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true },
@@ -205,7 +205,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         )
       allow(fake_api).to receive(:post)
         .with(
-          'hackneyrepairs/v1/work_orders/09124578/appointments',
+          'repairs/v1/work_orders/09124578/appointments',
           beginDate: '2017-10-11T12:00:00Z',
           endDate: '2017-10-11T17:00:00Z',
         )
@@ -276,7 +276,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       end
 
       expect(fake_api).to have_received(:post).with(
-        'hackneyrepairs/v1/repairs',
+        'repairs/v1/repairs',
         priority: 'N',
         problemDescription: "Room: Kitchen\n\nMy sink is blocked",
         propertyReference: '00000504',
@@ -290,7 +290,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       )
 
       expect(fake_api).to have_received(:post).with(
-        'hackneyrepairs/v1/work_orders/09124578/appointments',
+        'repairs/v1/work_orders/09124578/appointments',
         beginDate: '2017-10-11T12:00:00Z',
         endDate: '2017-10-11T17:00:00Z',
       )

--- a/spec/features/resident_can_submit_another_repair_spec.rb
+++ b/spec/features/resident_can_submit_another_repair_spec.rb
@@ -285,7 +285,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           telephoneNumber: '078 98765 432',
         },
         workOrders: [
-          { sorCode: '0078965' },
+          {
+            sorCode: '0078965',
+            estimatedunits: '1'
+          },
         ]
       )
 

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(question: 'What is the problem?', answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])
@@ -72,8 +72,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(question: 'What is the problem?', answers: [{ 'text' => 'skip' }])
@@ -172,8 +172,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])
@@ -224,8 +224,8 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/abc123').and_return(property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -288,7 +288,7 @@ RSpec.feature 'Resident can navigate back', js: true do
       'postcode' => 'N1 6NU',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -326,7 +326,7 @@ RSpec.feature 'Resident can navigate back', js: true do
 
   scenario 'going back from the address selection page' do
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E8 5TQ').and_return('results' => [])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [])
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -15,10 +15,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'postcode' => 'E5 8TE',
       }
       fake_api = instance_double(JsonApi)
-      allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
-      allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000503').and_return(property)
+      allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+      allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
       allow(fake_api).to receive(:post)
-        .with('hackneyrepairs/v1/repairs', anything)
+        .with('repairs/v1/repairs', anything)
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
@@ -32,7 +32,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           ]
         )
       allow(fake_api).to receive(:get)
-        .with('hackneyrepairs/v1/repairs/00367923')
+        .with('repairs/v1/repairs/00367923')
         .and_return(
           'repairRequestReference' => '00367923',
           'priority' => 'N',
@@ -46,7 +46,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           ]
         )
       allow(fake_api).to receive(:get)
-        .with('hackneyrepairs/v1/work_orders/09124578/available_appointments')
+        .with('repairs/v1/work_orders/09124578/available_appointments')
         .and_return(
           'results' => [
             { 'beginDate' => '2017-10-11T10:00:00Z', 'endDate' => '2017-10-11T12:00:00Z', 'bestSlot' => true },
@@ -55,7 +55,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         )
       allow(fake_api).to receive(:post)
         .with(
-          'hackneyrepairs/v1/work_orders/09124578/appointments',
+          'repairs/v1/work_orders/09124578/appointments',
           beginDate: '2017-10-11T12:00:00Z',
           endDate: '2017-10-11T17:00:00Z',
         )
@@ -152,7 +152,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       end
 
       expect(fake_api).to have_received(:post).with(
-        'hackneyrepairs/v1/repairs',
+        'repairs/v1/repairs',
         priority: 'N',
         problemDescription: "Room: Kitchen\n\nMy sink is blocked",
         propertyReference: '00000503',
@@ -166,7 +166,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       )
 
       expect(fake_api).to have_received(:post).with(
-        'hackneyrepairs/v1/work_orders/09124578/appointments',
+        'repairs/v1/work_orders/09124578/appointments',
         beginDate: '2017-10-11T12:00:00Z',
         endDate: '2017-10-11T17:00:00Z',
       )
@@ -180,10 +180,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('hackneyrepairs/v1/repairs', anything)
+      .with('repairs/v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -191,7 +191,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'propertyReference' => '00000503',
       )
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/repairs/00367923')
+      .with('repairs/v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -267,7 +267,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'hackneyrepairs/v1/repairs',
+      'repairs/v1/repairs',
       priority: 'N',
       problemDescription: "Callback requested: between 8am and 5pm\n\nMy sink is blocked",
       propertyReference: '00000503',

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -161,7 +161,10 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           telephoneNumber: '078 98765 432',
         },
         workOrders: [
-          { sorCode: '0078965' },
+          {
+            sorCode: '0078965',
+            estimatedunits: '1'
+          },
         ]
       )
 

--- a/spec/features/residents_see_nice_errors_spec.rb
+++ b/spec/features/residents_see_nice_errors_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Error pages' do
     fake_api = instance_double(JsonApi)
     connection_error = JsonApi::ConnectionError.new('Failed to open TCP connection to api_server:8000 (getaddrinfo: nodename nor servname provided, or not known)')
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/properties?postcode=E5 8TE')
+      .with('repairs/v1/properties?postcode=E5 8TE')
       .and_raise connection_error
     allow(JsonApi).to receive(:new).and_return(fake_api)
 

--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -127,7 +127,10 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
         telephoneNumber: '078 98765 432',
       },
       workOrders: [
-        { sorCode: '0078965' },
+        {
+          sorCode: '0078965',
+          estimatedunits: '1'
+        },
       ]
     )
   end

--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -8,10 +8,10 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
       'postcode' => 'E5 8TE',
     }
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
     allow(fake_api).to receive(:post)
-      .with('hackneyrepairs/v1/repairs', anything)
+      .with('repairs/v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -25,7 +25,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
         ]
       )
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/repairs/00367923')
+      .with('repairs/v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -39,7 +39,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
         ]
       )
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/work_orders/09124578/available_appointments')
+      .with('repairs/v1/work_orders/09124578/available_appointments')
       .and_return(
         'results' => []
       )
@@ -118,7 +118,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
     end
 
     expect(fake_api).to have_received(:post).with(
-      'hackneyrepairs/v1/repairs',
+      'repairs/v1/repairs',
       priority: 'N',
       problemDescription: "Room: Kitchen\n\nMy sink is blocked",
       propertyReference: '00000503',

--- a/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
+++ b/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
@@ -9,13 +9,13 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
     }
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/properties?postcode=E5 8TE')
+      .with('repairs/v1/properties?postcode=E5 8TE')
       .and_return('results' => [property])
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/properties/00000512')
+      .with('repairs/v1/properties/00000512')
       .and_return(property)
     allow(fake_api).to receive(:post)
-      .with('hackneyrepairs/v1/repairs', anything)
+      .with('repairs/v1/repairs', anything)
       .and_return(
         'repairRequestReference' => '00367923',
         'priority' => 'N',
@@ -29,7 +29,7 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
         ],
       )
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/repairs/00367923')
+      .with('repairs/v1/repairs/00367923')
       .and_return(
         'repairRequestReference' => '00367923',
         'orderReference' => '09124578',
@@ -44,7 +44,7 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
         ],
       )
     allow(fake_api).to receive(:get)
-      .with('hackneyrepairs/v1/work_orders/09124578/available_appointments')
+      .with('repairs/v1/work_orders/09124578/available_appointments')
       .and_return(
         'results' => [
           {
@@ -55,7 +55,7 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
         ]
       )
     allow(fake_api).to receive(:post)
-      .with('hackneyrepairs/v1/work_orders/09124578/appointments', anything)
+      .with('repairs/v1/work_orders/09124578/appointments', anything)
       .and_return(
         'beginDate' => '2017-11-27T10:00:00Z',
         'endDate' => '2017-11-27T12:00:00Z'

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -9,8 +9,8 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/zzz').and_return(matching_property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'skip' }])
@@ -71,8 +71,8 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     }
 
     fake_api = instance_double(JsonApi)
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
-    allow(fake_api).to receive(:get).with('hackneyrepairs/v1/properties/zzz').and_return(matching_property)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/zzz').and_return(matching_property)
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => 'fake_code' }])

--- a/spec/models/repair_spec.rb
+++ b/spec/models/repair_spec.rb
@@ -70,4 +70,19 @@ RSpec.describe Repair do
       expect { Repair.new(repair_data).request_reference }.to raise_error(KeyError)
     end
   end
+
+  describe '#supplier_reference' do
+    it 'returns the supplier reference from the repair' do
+      repair_data = {
+        'repairRequestReference' => '00004578',
+        'problemDescription' => 'My bath is broken',
+        'priority' => 'N',
+        'propertyReference' => '00034713',
+        'workOrders' => [
+          'supplierRef' => '123'
+        ]
+      }
+      expect(Repair.new(repair_data).supplier_reference).to eq '123'
+    end
+  end
 end

--- a/spec/queries/hackney_api_spec.rb
+++ b/spec/queries/hackney_api_spec.rb
@@ -33,7 +33,7 @@ describe HackneyApi do
         'postcode' => 'N1 1AA',
       }
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:get).with('hackneyrepairs/v1/properties/cre045').and_return(results)
+      allow(json_api).to receive(:get).with('repairs/v1/properties/cre045').and_return(results)
       api = HackneyApi.new(json_api)
 
       expect(api.get_property(property_reference: 'cre045')).to eql results
@@ -43,7 +43,7 @@ describe HackneyApi do
   describe '#create_repair' do
     it 'sends repair creation parameters' do
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:post).with('hackneyrepairs/v1/repairs', anything)
+      allow(json_api).to receive(:post).with('repairs/v1/repairs', anything)
 
       api = HackneyApi.new(json_api)
       repair_params = {
@@ -55,7 +55,7 @@ describe HackneyApi do
 
       expect(json_api).to have_received(:post)
         .with(
-          'hackneyrepairs/v1/repairs',
+          'repairs/v1/repairs',
           priority: 'U',
           problemDescription: 'It is broken',
           propertyReference: '01234567',
@@ -66,7 +66,7 @@ describe HackneyApi do
       json_api = instance_double('JsonApi')
       result = double('api result')
       allow(json_api).to receive(:post)
-        .with('hackneyrepairs/v1/repairs', anything)
+        .with('repairs/v1/repairs', anything)
         .and_return result
 
       api = HackneyApi.new(json_api)
@@ -89,7 +89,7 @@ describe HackneyApi do
         ],
       }
       json_api = instance_double('JsonApi')
-      allow(json_api).to receive(:get).with('hackneyrepairs/v1/repairs/00045678').and_return(result)
+      allow(json_api).to receive(:get).with('repairs/v1/repairs/00045678').and_return(result)
       api = HackneyApi.new(json_api)
 
       expect(api.get_repair(repair_request_reference: '00045678')).to eql result
@@ -113,7 +113,7 @@ describe HackneyApi do
 
       json_api = instance_double('JsonApi')
       result = { 'results' => appointments }
-      allow(json_api).to receive(:get).with('hackneyrepairs/v1/work_orders/00412371/available_appointments').and_return(result)
+      allow(json_api).to receive(:get).with('repairs/v1/work_orders/00412371/available_appointments').and_return(result)
       api = HackneyApi.new(json_api)
 
       expect(api.list_available_appointments(work_order_reference: '00412371')).to eql appointments
@@ -131,7 +131,7 @@ describe HackneyApi do
       allow(json_api)
         .to receive(:post)
         .with(
-          'hackneyrepairs/v1/work_orders/00412371/appointments',
+          'repairs/v1/work_orders/00412371/appointments',
           beginDate: '2017-11-01T14:00:00Z',
           endDate: '2017-11-01T16:30:00Z'
         )

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -265,11 +265,11 @@ RSpec.describe JsonApi do
         json_api = JsonApi.new(
           api_root: 'http://hackney.api:8000',
         )
-        stub_request(:get, 'http://hackney.api:8000/hackneyrepairs/v1/repairs/00012345')
+        stub_request(:get, 'http://hackney.api:8000/repairs/v1/repairs/00012345')
 
-        json_api.get('hackneyrepairs/v1/repairs/00012345')
+        json_api.get('repairs/v1/repairs/00012345')
 
-        expect(a_request(:get, 'http://hackney.api:8000/hackneyrepairs/v1/repairs/00012345'))
+        expect(a_request(:get, 'http://hackney.api:8000/repairs/v1/repairs/00012345'))
           .to have_been_made.once
       end
     end
@@ -279,6 +279,7 @@ RSpec.describe JsonApi do
     it 'adds the API token to the header of the request' do
       ClimateControl.modify(HACKNEY_API_TOKEN: 'foobar') do
         stub_request(:post, "http://hackney.api:8000/repairs/v1/repairs")
+
 
         json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
 
@@ -298,12 +299,12 @@ RSpec.describe JsonApi do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       request_params = { priority: 'N', problemDescription: 'It is broken', propertyReference: '00001234' }
       request_json = request_params.to_json
-      stub_request(:post, 'http://hackney.api:8000/hackneyrepairs/v1/repairs')
+      stub_request(:post, 'http://hackney.api:8000/repairs/v1/repairs')
         .with(body: request_json)
 
-      json_api.post('hackneyrepairs/v1/repairs', request_params)
+      json_api.post('repairs/v1/repairs', request_params)
 
-      expect(a_request(:post, 'http://hackney.api:8000/hackneyrepairs/v1/repairs')
+      expect(a_request(:post, 'http://hackney.api:8000/repairs/v1/repairs')
         .with(
           body: request_json,
           headers: { content_type: 'application/json' }
@@ -313,20 +314,20 @@ RSpec.describe JsonApi do
     it 'parses a JSON response' do
       json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
       response_params = { repair_request_id: '00045678' }
-      stub_request(:post, 'http://hackney.api:8000/hackneyrepairs/v1/repairs')
+      stub_request(:post, 'http://hackney.api:8000/repairs/v1/repairs')
         .to_return(body: response_params.to_json)
 
-      result = json_api.post('hackneyrepairs/v1/repairs', {})
+      result = json_api.post('repairs/v1/repairs', {})
       expect(result).to eq('repair_request_id' => '00045678')
     end
 
     context 'when the response was not valid JSON' do
       it 'raises an exception' do
         json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
-        stub_request(:post, 'http://hackney.api:8000/hackneyrepairs/v1/repairs')
+        stub_request(:post, 'http://hackney.api:8000/repairs/v1/repairs')
           .to_return(body: 'not found')
 
-        expect { json_api.post('/hackneyrepairs/v1/repairs', {}) }
+        expect { json_api.post('/repairs/v1/repairs', {}) }
           .to raise_error(JsonApi::InvalidResponseError, "765: unexpected token at 'not found'")
       end
     end

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -39,23 +39,20 @@ RSpec.describe JsonApi do
 
   describe '#get' do
     it 'adds the API token to the header of the request' do
-      cached_api_token = ENV['HACKNEY_API_TOKEN']
-      ENV['HACKNEY_API_TOKEN'] = 'foobar'
+      ClimateControl.modify(HACKNEY_API_TOKEN: 'foobar') do
+        stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
 
-      stub_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
 
-      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        json_api.get('properties?postcode=A1 1AA')
 
-      json_api.get('properties?postcode=A1 1AA')
-
-      expect(a_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
-        .with(
-          headers: {
-            'X-Api-Key' => 'foobar',
-          }
-        )).to have_been_made.once
-
-      ENV['HACKNEY_API_TOKEN'] = cached_api_token
+        expect(a_request(:get, 'http://hackney.api:8000/properties?postcode=A1%201AA')
+          .with(
+            headers: {
+              'X-Api-Key' => 'foobar',
+            }
+          )).to have_been_made.once
+      end
     end
 
     it 'parses a JSON response' do
@@ -280,24 +277,21 @@ RSpec.describe JsonApi do
 
   describe '#post' do
     it 'adds the API token to the header of the request' do
-      cached_api_token = ENV['HACKNEY_API_TOKEN']
-      ENV['HACKNEY_API_TOKEN'] = 'foobar'
+      ClimateControl.modify(HACKNEY_API_TOKEN: 'foobar') do
+        stub_request(:post, "http://hackney.api:8000/repairs/v1/repairs")
 
-      stub_request(:post, "http://hackney.api:8000/hackneyrepairs/v1/repairs")
+        json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
 
-      json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
+        json_api.post('repairs/v1/repairs', {})
 
-      json_api.post('hackneyrepairs/v1/repairs', {})
-
-      expect(a_request(:post, 'http://hackney.api:8000/hackneyrepairs/v1/repairs')
-        .with(
-          headers: {
-            content_type: 'application/json',
-            'X-Api-Key' => 'foobar',
-          }
-        )).to have_been_made.once
-
-      ENV['HACKNEY_API_TOKEN'] = cached_api_token
+        expect(a_request(:post, 'http://hackney.api:8000/repairs/v1/repairs')
+          .with(
+            headers: {
+              content_type: 'application/json',
+              'X-Api-Key' => 'foobar',
+            }
+          )).to have_been_made.once
+      end
     end
 
     it 'sends a JSON payload' do

--- a/spec/services/create_repair_spec.rb
+++ b/spec/services/create_repair_spec.rb
@@ -127,7 +127,10 @@ RSpec.describe CreateRepair do
             telephoneNumber: '020 8534 1234',
           },
           workOrders: [
-            { sorCode: '002034' },
+            {
+              sorCode: '002034',
+              estimatedunits: '1'
+            },
           ],
         )
     end


### PR DESCRIPTION
- Hackney has built a new version of their Repairs API which they'd like this service to transition to. The old one https://github.com/LBHackney-IT/HackneyRepairsAPI has now been archived. The new one looks to have been built on top of the original with around 500 new commits at this point in time https://github.com/LBHackney-IT/Hackney_Repairs_API.
- Whilst we are moving to a new version of the API both new and old paths include `v1` 
- The old API required a proxy and certificates to provision a connection to the old API.. The new one requires only an API token so the proxy and certificates will no longer be required after this change
- This services uses 5 endpoints all of which have been updated and tested against the new API:

```
GET hackneyrepairs/v1/properties/:property_reference
POST hackneyrepairs/v1/repairs
GET hackneyrepairs/v1/repairs/:repair_reference
GET hackneyrepairs/v1/work_orders/:order_reference/available_appointments
POST hackneyrepairs/v1/work_orders/:order_reference/appointments
```

There were a few tweaks needed in the repairs endpoints, the property and work orders/appointments worked straight away. These are detailed in the commits.