### PR TITLE
Repairs for properties with cautionary contacts cannot create appointments

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -36,13 +36,7 @@ class AddressesController < ApplicationController
   end
 
   def continue_to_appointment_booking?
-    RepairParams.new(selected_answer_store.selected_answers).diagnosed? && !cautionary_contact?
-  end
-
-  def cautionary_contact?
-    result = HackneyApi.new.get_cautionary_contacts(property_reference: property_reference)
-    return true unless result['results']['alertCodes'] == [nil] && result['results']['callerNotes'] == [nil]
-
-    false
+    RepairParams.new(selected_answer_store.selected_answers).diagnosed? &&
+      FindCautionaryContact.new(property_reference: property_reference).not_present?
   end
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -23,11 +23,26 @@ class AddressesController < ApplicationController
     params.require(:address_form).permit(:property_reference, :postcode)
   end
 
+  def property_reference
+    address_form_params[:property_reference]
+  end
+
   def address_success_path
-    if RepairParams.new(selected_answer_store.selected_answers).diagnosed?
+    if continue_to_appointment_booking?
       contact_details_path
     else
       contact_details_with_callback_path
     end
+  end
+
+  def continue_to_appointment_booking?
+    RepairParams.new(selected_answer_store.selected_answers).diagnosed? && !cautionary_contact?
+  end
+
+  def cautionary_contact?
+    result = HackneyApi.new.get_cautionary_contacts(property_reference: property_reference)
+    return true unless result['results']['alertCodes'] == [nil] && result['results']['callerNotes'] == [nil]
+
+    false
   end
 end

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -38,4 +38,8 @@ class HackneyApi
       endDate: end_date
     )
   end
+
+  def get_cautionary_contacts(property_reference:)
+    @json_api.get("repairs/v1/cautionary_contact/?reference=#{property_reference}")
+  end
 end

--- a/app/services/find_cautionary_contact.rb
+++ b/app/services/find_cautionary_contact.rb
@@ -1,0 +1,30 @@
+class FindCautionaryContact
+  attr_accessor :api, :property_reference
+
+  def initialize(api: HackneyApi.new, property_reference:)
+    self.api = api
+    self.property_reference = property_reference
+  end
+
+  def present?
+    result = api.get_cautionary_contacts(property_reference: property_reference)
+    return true if caution?(api_result: result)
+
+    false
+  end
+
+  def not_present?
+    !present?
+  end
+
+  private
+
+  def caution?(api_result: {})
+    alert_codes = api_result.dig('results', 'alertCodes') || []
+    caller_notes = api_result.dig('results', 'callerNotes') || []
+
+    values_for_no_caution = [[nil], []]
+    
+    !values_for_no_caution.include?(alert_codes) || !values_for_no_caution.include?(caller_notes)
+  end
+end

--- a/spec/features/resident_can_submit_another_repair_spec.rb
+++ b/spec/features/resident_can_submit_another_repair_spec.rb
@@ -14,6 +14,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=00000503')
+      .and_return({'results'=>{'alertCodes'=>[nil], 'callerNotes'=>[nil]}})
     allow(fake_api).to receive(:post)
       .with('repairs/v1/repairs', anything)
       .and_return(
@@ -30,6 +32,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         'problem' => "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other",
         'propertyReference' => '00000503',
       )
+
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_google_sheets_logger
@@ -167,6 +170,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       }
       allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
       allow(fake_api).to receive(:get).with('repairs/v1/properties/00000504').and_return(property)
+      allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=00000504')
+        .and_return({'results'=>{'alertCodes'=>[nil], 'callerNotes'=>[nil]}})
       allow(fake_api).to receive(:post)
         .with('repairs/v1/repairs', anything)
         .and_return(

--- a/spec/features/residents_can_navigate_back_spec.rb
+++ b/spec/features/residents_can_navigate_back_spec.rb
@@ -10,6 +10,8 @@ RSpec.feature 'Resident can navigate back', js: true do
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('repairs/v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=abc123')
+      .and_return({'results'=>{'alertCodes'=>[nil], 'callerNotes'=>[nil]}})
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(question: 'What is the problem?', answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])
@@ -174,6 +176,8 @@ RSpec.feature 'Resident can navigate back', js: true do
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E8 5TQ').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('repairs/v1/properties/abc123').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=abc123')
+      .and_return({'results'=>{'alertCodes'=>[nil], 'callerNotes'=>[nil]}})
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => '12345678' }])

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -17,6 +17,8 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
       fake_api = instance_double(JsonApi)
       allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
       allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
+      allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=00000503')
+        .and_return({'results'=>{'alertCodes'=>[nil], 'callerNotes'=>[nil]}})
       allow(fake_api).to receive(:post)
         .with('repairs/v1/repairs', anything)
         .and_return(
@@ -278,6 +280,152 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
         name: 'John Evans',
         telephoneNumber: '078 98765 432',
       },
+    )
+  end
+
+  scenario 'when the issue was diagnosed but the property has a cautionary contact assigned' do
+    property = {
+      'propertyReference' => '00000503',
+      'address' => 'Ross Court 23',
+      'postcode' => 'E5 8TE',
+    }
+    fake_api = instance_double(JsonApi)
+    allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
+    allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:post)
+      .with('repairs/v1/repairs', anything)
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other",
+        'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ]
+      )
+    allow(fake_api).to receive(:get)
+      .with('repairs/v1/repairs/00367923')
+      .and_return(
+        'repairRequestReference' => '00367923',
+        'priority' => 'N',
+        'problem' => "My sink is blocked\n\nRoom: Other\n\nLast question: \"Which room?\" -> Other",
+        'propertyReference' => '00000503',
+        'workOrders' => [
+          {
+            'sorCode' => '0078965',
+            'workOrderReference' => '09124578',
+          },
+        ]
+      )
+    allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=00000503')
+      .and_return({'results'=>{'alertCodes'=>['CV'], 'callerNotes'=>[nil]}})
+
+    allow(JsonApi).to receive(:new).and_return(fake_api)
+
+    stub_google_sheets_logger
+
+    fake_question_set = instance_double(QuestionSet)
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('which_room')
+      .and_return(
+        Question.new(
+          'id' => 'which_room',
+          'question' => 'Which room?',
+          'answers' => [
+            { 'text' => 'Kitchen', 'next' => 'kitchen' },
+            { 'text' => 'Bathroom' },
+            { 'text' => 'Other' },
+          ],
+        )
+      )
+    allow(fake_question_set)
+      .to receive(:find)
+      .with('kitchen')
+      .and_return(
+        Question.new(
+          'id' => 'kitchen',
+          'question' => 'Is your tap broken?',
+          'answers' => [
+            { 'text' => 'Yes', 'sor_code' => '0078965', 'desc' => 'kitchen_problem' },
+            { 'text' => 'No' },
+          ],
+        )
+      )
+    allow(QuestionSet).to receive(:new).and_return(fake_question_set)
+
+    visit '/'
+    click_on 'Start'
+
+    # Emergency page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Filter page:
+    choose_radio_button 'No'
+    click_on 'Continue'
+
+    # Fake decision tree
+    choose_radio_button 'Kitchen'
+    click_on 'Continue'
+
+    choose_radio_button 'Yes'
+    click_on 'Continue'
+
+    # Describe problem:
+    fill_in 'describe_repair_form_description', with: 'My sink is blocked'
+    click_on 'Continue'
+
+    # Address search:
+    fill_in 'Postcode', with: 'E5 8TE'
+    click_on 'Find my address'
+
+    # Address selection:
+    choose_radio_button 'Ross Court 23'
+    click_on 'Continue'
+
+    # Contact details - last page before confirmation:
+    fill_in 'Full name', with: 'John Evans'
+    fill_in 'Telephone number', with: '078 98765 432'
+    check 'morning (8am to midday)'
+    check 'afternoon (midday to 5pm)'
+    click_on 'Continue'
+
+    aggregate_failures do
+      within '#confirmation' do
+        expect(page).to have_content 'Your reference number is 09124578'
+        expect(page).to have_content 'between 8am and 5pm'
+      end
+
+      within '#summary' do
+        expect(page).to have_content t('confirmation.summary.name', name: 'John Evans')
+        expect(page).to have_content t('confirmation.summary.phone', phone: '07898765432')
+        expect(page).to have_content t('confirmation.summary.address', address: 'Ross Court 23, E5 8TE')
+      end
+    end
+
+    expect(fake_api).to have_received(:post).with(
+      'repairs/v1/repairs',
+      priority: 'N',
+      problemDescription: "Room: Kitchen\nCallback requested: between 8am and 5pm\n\nMy sink is blocked",
+      propertyReference: '00000503',
+      contact: {
+        name: 'John Evans',
+        telephoneNumber: '078 98765 432',
+      },
+      workOrders: [
+        {
+          sorCode: '0078965',
+          estimatedunits: '1',
+        }
+      ]
+    )
+
+    expect(fake_api).not_to have_received(:post).with(
+      'repairs/v1/work_orders/09124578/appointments', anything, anything
     )
   end
 end

--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -10,6 +10,8 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [property])
     allow(fake_api).to receive(:get).with('repairs/v1/properties/00000503').and_return(property)
+    allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=00000503')
+      .and_return({'results'=>{'alertCodes'=>[nil], 'callerNotes'=>[nil]}})
     allow(fake_api).to receive(:post)
       .with('repairs/v1/repairs', anything)
       .and_return(

--- a/spec/features/users_cannot_submit_incomplete_forms_spec.rb
+++ b/spec/features/users_cannot_submit_incomplete_forms_spec.rb
@@ -73,6 +73,8 @@ RSpec.feature 'Users cannot submit incomplete forms' do
     fake_api = instance_double(JsonApi)
     allow(fake_api).to receive(:get).with('repairs/v1/properties?postcode=E5 8TE').and_return('results' => [matching_property])
     allow(fake_api).to receive(:get).with('repairs/v1/properties/zzz').and_return(matching_property)
+    allow(fake_api).to receive(:get).with('repairs/v1/cautionary_contact/?reference=zzz')
+      .and_return({'results'=>{'alertCodes'=>[nil], 'callerNotes'=>[nil]}})
     allow(JsonApi).to receive(:new).and_return(fake_api)
 
     stub_diagnosis_question(answers: [{ 'text' => 'diagnose', 'sor_code' => 'fake_code' }])

--- a/spec/queries/json_api_spec.rb
+++ b/spec/queries/json_api_spec.rb
@@ -280,7 +280,6 @@ RSpec.describe JsonApi do
       ClimateControl.modify(HACKNEY_API_TOKEN: 'foobar') do
         stub_request(:post, "http://hackney.api:8000/repairs/v1/repairs")
 
-
         json_api = JsonApi.new(api_root: 'http://hackney.api:8000')
 
         json_api.post('repairs/v1/repairs', {})

--- a/spec/services/find_cautionary_contact_spec.rb
+++ b/spec/services/find_cautionary_contact_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'app/services/find_cautionary_contact'
+
+RSpec.describe FindCautionaryContact do
+  describe '#present?' do
+    it 'returns true if there is no cautionary contact information' do
+      fake_cautionary_contact = { 'results' => { 'alertCodes' => [nil], 'callerNotes'=> [nil] } }
+      fake_api = instance_double('HackneyApi', get_cautionary_contacts: fake_cautionary_contact)
+
+      expect(fake_api).to receive(:get_cautionary_contacts).with(property_reference: '123' )
+
+      result = described_class.new(api: fake_api, property_reference: '123').present?
+
+      expect(result).to eq(false)
+    end
+
+    context 'when there is no cautionary contact information but it is expressed as empty arrays' do
+      it 'returns true' do
+        fake_cautionary_contact = { 'results' => { 'alertCodes' => [], 'callerNotes'=> [] } }
+        fake_api = instance_double('HackneyApi', get_cautionary_contacts: fake_cautionary_contact)
+
+        result = described_class.new(api: fake_api, property_reference: '123').present?
+
+        expect(result).to eq(false)
+      end
+    end
+
+    context 'when there is cautionary contact information through an alert code' do
+      it 'returns true' do
+        fake_cautionary_contact = { 'results' => { 'alertCodes' => ['CV'], 'callerNotes'=> [] } }
+        fake_api = instance_double('HackneyApi', get_cautionary_contacts: fake_cautionary_contact)
+
+        result = described_class.new(api: fake_api, property_reference: '123').present?
+
+        expect(result).to eq(true)
+      end
+    end
+
+    context 'when there is cautionary contact information through a caller note' do
+      it 'returns true' do
+        fake_cautionary_contact = { 'results' => { 'alertCodes' => [nil], 'callerNotes'=> ['Arrange any visits with M.Donald on 07123456789'] } }
+        fake_api = instance_double('HackneyApi', get_cautionary_contacts: fake_cautionary_contact)
+
+        result = described_class.new(api: fake_api, property_reference: '123').present?
+
+        expect(result).to eq(true)
+      end
+    end
+
+    context 'when there alert codes and caller notes' do
+      it 'returns true' do
+        fake_cautionary_contact = { 'results' => { 'alertCodes' => ['CV'], 'callerNotes'=> ['Arrange any visits with M.Donald on 07123456789'] } }
+        fake_api = instance_double('HackneyApi', get_cautionary_contacts: fake_cautionary_contact)
+
+        result = described_class.new(api: fake_api, property_reference: '123').present?
+
+        expect(result).to eq(true)
+      end
+    end
+
+    context 'when unexpected values are returned' do
+      it 'returns true' do
+        fake_cautionary_contact = { 'results' => { 'I am an unknown key' => ['CV'], 'callerNotes'=> 'I am a string, not an array' } }
+        fake_api = instance_double('HackneyApi', get_cautionary_contacts: fake_cautionary_contact)
+
+        result = described_class.new(api: fake_api, property_reference: '123').present?
+
+        expect(result).to eq(true)
+      end
+    end
+  end
+
+  describe '#not_present?' do
+    it 'returns the inverted result of present?' do
+      fake_cautionary_contact = { 'results' => { 'alertCodes' => ['CV'], 'callerNotes'=> ['Arrange any visits with M.Donald on 07123456789'] } }
+      fake_api = instance_double('HackneyApi', get_cautionary_contacts: fake_cautionary_contact)
+
+      present_result = described_class.new(api: fake_api, property_reference: '123').present?
+      not_present_result = described_class.new(api: fake_api, property_reference: '123').not_present?
+
+      expect(present_result).to eq(true)
+      expect(not_present_result).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
* If a cautionary contact is found for the property the repair is being raised against, the user will be put into the same user journey called callback (also known as "phone back" and not to be confused by a type of webhook) where the user will arrange a time for phone call to be made where an appointment is then booked.
* Commits include the nuance around the response from the Repair API where `[nil]` is the same as `false`. I have also accounted for `[]` and error handling for unexpected values.