### PR TITLE
Call Google Drive calls in the background

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'business_time'
+gem 'delayed_job_active_record'
 gem 'faker' # Use in all environments until we have a real API
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,11 @@ GEM
     crass (1.0.4)
     declarative (0.0.10)
     declarative-option (0.1.0)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     docile (1.1.5)
     dotenv (2.2.1)
@@ -338,6 +343,7 @@ DEPENDENCIES
   business_time
   capybara
   climate_control
+  delayed_job_active_record
   dotenv-rails
   factory_girl_rails
   faker

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+worker: rake jobs:work

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -33,9 +33,8 @@ class ContactDetailsController < ApplicationController
   end
 
   def save_and_log_repair
-    result =
-      CreateRepair.new.call(answers: selected_answer_store.selected_answers)
-    GoogleSheetLogger.new.call(result, 'booking')
+    result = CreateRepair.new.call(answers: selected_answer_store.selected_answers)
+    GoogleSheetLoggingJob.perform_later(result.attributes, 'booking')
     result
   end
 end

--- a/app/controllers/contact_details_with_callback_controller.rb
+++ b/app/controllers/contact_details_with_callback_controller.rb
@@ -25,7 +25,7 @@ class ContactDetailsWithCallbackController < ApplicationController
     if contact_details_saver.save(@form) && callback_time_saver.save(@form)
       result =
         CreateRepair.new.call(answers: selected_answer_store.selected_answers)
-      GoogleSheetLogger.new.call(result, 'callback')
+      GoogleSheetLoggingJob.perform_later(result.attributes, 'callback')
 
       redirect_to confirmation_path(result.request_reference)
     else

--- a/app/jobs/google_sheet_logging_job.rb
+++ b/app/jobs/google_sheet_logging_job.rb
@@ -1,0 +1,5 @@
+class GoogleSheetLoggingJob < ApplicationJob
+  def perform(repair_attributes, callback)
+    GoogleSheetLogger.new.call(repair_attributes, callback)
+  end
+end

--- a/app/models/repair.rb
+++ b/app/models/repair.rb
@@ -27,4 +27,14 @@ class Repair
   def priority
     @repair_data.fetch('priority')
   end
+
+  def attributes
+    {
+      requested_at: Time.zone.now.strftime('%F %R'),
+      request_reference: request_reference,
+      sor_code: sor_code,
+      supplier_reference: supplier_reference,
+      priority: priority
+    }
+  end
 end

--- a/app/services/google_sheet_logger.rb
+++ b/app/services/google_sheet_logger.rb
@@ -10,13 +10,13 @@ class GoogleSheetLogger
     @worksheet = @spreadsheet.worksheets[0]
   end
 
-  def call(repair, callback)
+  def call(repair_attributes, callback)
     row = @worksheet.num_rows + 1
-    @worksheet[row, 1] = Time.zone.now.strftime('%F %R')
-    @worksheet[row, 2] = repair.request_reference
-    @worksheet[row, 3] = repair.sor_code
-    @worksheet[row, 4] = repair.supplier_reference
-    @worksheet[row, 5] = repair.priority
+    @worksheet[row, 1] = repair_attributes[:requested_at]
+    @worksheet[row, 2] = repair_attributes[:request_reference]
+    @worksheet[row, 3] = repair_attributes[:sor_code]
+    @worksheet[row, 4] = repair_attributes[:supplier_reference]
+    @worksheet[row, 5] = repair_attributes[:priority]
     @worksheet[row, 6] = callback
     @worksheet.save
   end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,7 @@ module HackneyRepairs
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/db/migrate/20191127151731_create_delayed_jobs.rb
+++ b/db/migrate/20191127151731_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20191127151731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
 
 end

--- a/spec/features/resident_can_submit_another_repair_spec.rb
+++ b/spec/features/resident_can_submit_another_repair_spec.rb
@@ -183,6 +183,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
             {
               'sorCode' => '0078965',
               'workOrderReference' => '09124578',
+              'supplierRef' => 'A3'
             },
           ]
         )
@@ -197,6 +198,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
             {
               'sorCode' => '0078965',
               'workOrderReference' => '09124578',
+              'supplierRef' => 'A3'
             },
           ]
         )

--- a/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
+++ b/spec/features/residents_can_see_confirmation_of_repair_request_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
             {
               'sorCode' => '0078965',
               'workOrderReference' => '09124578',
+              'supplierRef' => 'A3'
             },
           ]
         )
@@ -44,6 +45,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
             {
               'sorCode' => '0078965',
               'workOrderReference' => '09124578',
+              'supplierRef' => 'A3'
             },
           ]
         )
@@ -303,6 +305,7 @@ RSpec.feature 'Resident can see a confirmation of their repair request' do
           {
             'sorCode' => '0078965',
             'workOrderReference' => '09124578',
+            'supplierRef' => 'A3'
           },
         ]
       )

--- a/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
+++ b/spec/features/residents_see_useful_message_when_no_appointments_available_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature 'Residents see a useful message when no appointments available' do
           {
             'sorCode' => '0078965',
             'workOrderReference' => '09124578',
+            'supplierRef' => 'A3'
           },
         ]
       )

--- a/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
+++ b/spec/features/users_can_report_a_repair_without_previous_answers_affecting_result_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'Users can report a repair without previous answers affecting the 
           {
             'sorCode' => '0078965',
             'workOrderReference' => '09124578',
+            'supplierRef' => 'A3'
           },
         ],
       )

--- a/spec/jobs/google_sheet_logging_job_spec.rb
+++ b/spec/jobs/google_sheet_logging_job_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe GoogleSheetLoggingJob do
+  describe '#call' do
+    it 'posts details to the sheet' do
+      repair_attributes = {
+        requested_at: '2019-11-27 14:25',
+        request_reference: '01234',
+        sor_code: '5678',
+        supplier_reference: 'W1',
+        priority: 'N'
+      }
+
+      logger = double('GoogleSheetLogger')
+
+      expect(GoogleSheetLogger).to receive(:new) { logger }
+      expect(logger).to receive(:call).with(repair_attributes, 'callback')
+
+      GoogleSheetLoggingJob.perform_now(repair_attributes, 'callback')
+    end
+  end
+end

--- a/spec/services/google_sheet_logger_spec.rb
+++ b/spec/services/google_sheet_logger_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 RSpec.describe GoogleSheetLogger do
   describe '#call' do
     it 'posts details to the sheet' do
-      fake_repair = instance_double(Repair)
-      allow(fake_repair).to receive(:request_reference).and_return('01234')
-      allow(fake_repair).to receive(:sor_code).and_return('5678')
-      allow(fake_repair).to receive(:supplier_reference).and_return('W1')
-      allow(fake_repair).to receive(:priority).and_return('N')
+      repair_attributes = {
+        requested_at: '2019-11-27 14:25',
+        request_reference: '01234',
+        sor_code: '5678',
+        supplier_reference: 'W1',
+        priority: 'N'
+      }
 
       fake_session = double
       fake_spreadsheet = double
@@ -27,8 +29,9 @@ RSpec.describe GoogleSheetLogger do
       allow(GoogleDrive::Session).to receive(:from_service_account_key)
         .and_return(fake_session)
 
-      GoogleSheetLogger.new.call(fake_repair, 'callback')
+      GoogleSheetLogger.new.call(repair_attributes, 'callback')
 
+      expect(fake_worksheet).to have_received(:[]=).with(2, 1, '2019-11-27 14:25')
       expect(fake_worksheet).to have_received(:[]=).with(2, 2, '01234')
       expect(fake_worksheet).to have_received(:[]=).with(2, 3, '5678')
       expect(fake_worksheet).to have_received(:[]=).with(2, 4, 'W1')


### PR DESCRIPTION
We've been getting a few issues coming out of Rollbar telling us that requests to create a repair are timing out because of Google drive. After a bit of back and forth, we decided that the best way to mitigate against this was to use workers to process these jobs. I decided that the best option was Delayed Job. I considered Sidekiq, as we already have Redis setup, but it's not recommended to mix data storage and job processing in the same Redis setup. We've got a Postgres Database hanging around not doing anything, so it seemed like the next obvious chose was DJ.