### PR TITLE
(fix) Do not reset answers when there are none

### DIFF
--- a/app/controllers/questions/start_controller.rb
+++ b/app/controllers/questions/start_controller.rb
@@ -1,7 +1,8 @@
 module Questions
   class StartController < ApplicationController
     def index
-      if params[:keep_address]
+      if params[:keep_address] && session[:selected_answers]
+
         selected_answer_store.reset_repair_questions!
       else
         reset_session

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Questions::StartController do
+  describe '#index' do
+    it 'only resets the questions if there are answers in the session' do
+      get :index, params: { keep_address: true }, session: nil
+
+      expect(response).to have_http_status 200
+    end
+  end
+
   describe '#submit' do
     context 'shows different content based on user choice' do
       it 'shows the gas page' do


### PR DESCRIPTION
We saw Rollbar errors from visits to `questions/start` with the
`keep_address` param set to `true` when there was not session with
answers to reset.

https://rollbar.com/dxw/Hackney-Repairs/items/77/occurrences/90813887448/