### PR TITLE
Fix broken build due to breaking PostgreSQL docker change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: HackneyRepairs_development
+          POSTGRES_HOST_AUTH_METHOD: trust
       - image: circleci/redis:4.0.14
 
     working_directory: ~/repo


### PR DESCRIPTION
A security patch installed in the PostgreSQL images required a password to be set for the superuser account. Because this image is only running in a test sandbox, we can safely skip this by adding a new environment variable to CircleCI's configuration.